### PR TITLE
Sprint 2 Phase 1: Core Interfaces for Multi-Simulation Architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,10 +144,22 @@ export class FileArgumentRepository implements IArgumentRepository {
 ```
 src/
 ├── core/                 # Business logic ONLY
-│   ├── entities/        # Domain entities (Argument, Agent, etc.)
+│   ├── entities/        # Domain entities (Agent - simulation-agnostic)
 │   ├── value-objects/   # Immutable values (ArgumentId, Timestamp)
 │   ├── repositories/    # Interface definitions ONLY
-│   └── services/        # Domain services (pure logic)
+│   ├── services/        # Domain services (pure logic)
+│   ├── simulation/      # Generic simulation interfaces (ISimulation, IAction)
+│   ├── voting/          # SHARED: Generic voting mechanics
+│   └── relationships/   # SHARED: Generic relationship graph
+│
+├── simulations/          # SIMULATION TYPES (self-contained)
+│   ├── debate/          # Debate simulation
+│   │   ├── entities/   # Argument, Rebuttal, Concession
+│   │   ├── DebateSimulation.ts
+│   │   ├── DebateConfig.ts
+│   │   └── index.ts
+│   └── decision/        # Future: Decision simulation
+│       └── ...
 │
 ├── application/         # Use case orchestration
 │   ├── commands/       # Command definitions
@@ -163,6 +175,9 @@ src/
 │
 ├── interfaces/          # User-facing adapters
 │   ├── cli/           # CLI commands
+│   │   └── commands/
+│   │       ├── base/  # Shared commands (init, status, log)
+│   │       └── debate/ # Debate-specific commands
 │   ├── api/           # REST routes
 │   ├── mcp/           # MCP tools
 │   └── sdk/           # Public SDK
@@ -174,6 +189,123 @@ src/
 - No storage code outside `infrastructure/`
 - No business logic outside `core/`
 - No HTTP/CLI code outside `interfaces/`
+- No simulation-specific code outside `simulations/<type>/`
+
+## Simulation Type Architecture (ADR-001)
+
+> **Reference**: See `docs/adr/ADR-001-simulation-type-registration.md` for full context
+
+### Decision: Static Registry with Composition
+
+Simulation types (debate, decision, brainstorm) are **self-contained modules** that:
+1. Live in `simulations/<type>/`
+2. Register explicitly in `SimulationTypeRegistry`
+3. **Compose** shared utilities from `core/` (not inherit)
+
+### Boundary Rules (CRITICAL)
+
+#### Rule 1: No Cross-Simulation Imports
+
+Simulation types MUST NOT import from each other:
+
+```typescript
+// ❌ NEVER: debate/ importing from decision/
+import { Proposal } from '../decision/entities/Proposal';
+
+// ❌ NEVER: decision/ importing from debate/
+import { Argument } from '../debate/entities/Argument';
+
+// ✅ OK: Both import from core/
+import { IAction } from '../../core/simulation/IAction';
+import { IVotingMechanism } from '../../core/voting/IVotingMechanism';
+```
+
+#### Rule 2: Core Knows Nothing About Specific Simulations
+
+```typescript
+// ❌ NEVER: core/ importing from simulations/
+import { Argument } from '../../simulations/debate/entities/Argument';
+import { DebateSimulation } from '../../simulations/debate/DebateSimulation';
+
+// ✅ OK: core/ defines interfaces that simulations implement
+export interface ISimulation<TConfig, TStatus> { ... }
+export interface IAction { ... }
+```
+
+#### Rule 3: Registry is the Only Cross-Boundary Point
+
+`SimulationTypeRegistry` is the **ONLY** place that imports multiple simulation configs:
+
+```typescript
+// src/core/simulation/SimulationTypeRegistry.ts
+// This is the ONLY file that knows about all simulation types
+import { DebateConfig } from '../../simulations/debate';
+import { DecisionConfig } from '../../simulations/decision';
+
+registry.register(DebateConfig);
+registry.register(DecisionConfig);
+```
+
+#### Rule 4: Shared Utilities Use Generics
+
+Shared code in `core/voting/` and `core/relationships/` works via interfaces:
+
+```typescript
+// ✅ CORRECT: Generic over ballot type
+interface IVotingMechanism<TBallot extends BaseBallot> {
+  recordVote(ballot: TBallot): Result<void, VotingError>;
+  hasConsensus(rules: VotingRules): boolean;
+}
+
+// Debate composes with CloseVote
+class DebateSimulation {
+  private voting: IVotingMechanism<CloseVote>;
+}
+
+// Decision composes with ApprovalVote
+class DecisionSimulation {
+  private voting: IVotingMechanism<ApprovalVote>;
+}
+```
+
+### What's Shared vs Simulation-Specific
+
+| Component | Location | Shared? |
+|-----------|----------|---------|
+| Voting mechanics | `core/voting/` | Yes - generic over ballot type |
+| Relationship graph | `core/relationships/` | Yes - generic over relationship type |
+| Agent entity | `core/entities/` | Yes - agents are simulation-agnostic |
+| Phases/Rounds | `simulations/<type>/` | No - semantics vary too much |
+| Domain entities | `simulations/<type>/entities/` | No - Argument, Proposal, Idea are type-specific |
+| Validation rules | `simulations/<type>/` | No - each type has own rules |
+
+### Adding a New Simulation Type
+
+1. Create `src/simulations/<type>/` directory
+2. Implement `ISimulation` interface
+3. Create config implementing `ISimulationConfig`
+4. Define type-specific entities in `entities/`
+5. Register in `SimulationTypeRegistry.ts`
+6. Add CLI commands in `interfaces/cli/commands/<type>/`
+
+### Violations That Will Be Rejected
+
+```typescript
+// ❌ Importing between simulation types
+import { Rebuttal } from '../debate/entities/Rebuttal';
+
+// ❌ Core depending on simulation
+import { DebatePhase } from '../../simulations/debate/DebatePhase';
+
+// ❌ Shared utility knowing about specific types
+class VoteCalculator {
+  calculateDebateConsensus(...) // NO! Must be generic
+}
+
+// ❌ Simulation-specific code in core/
+// File: src/core/entities/Argument.ts  // WRONG LOCATION
+// Should be: src/simulations/debate/entities/Argument.ts
+```
 
 ## Implementation Checklist
 
@@ -358,12 +490,15 @@ fix(infra): handle concurrent file writes
 
 For ANY architectural change:
 
-1. Create ADR file: `.docs/adr/YYYY-MM-DD-title.md`
+1. Create ADR file: `docs/adr/ADR-NNN-title.md`
 2. Include:
    - Context: Why considering change
    - Decision: What we're doing
    - Consequences: Trade-offs
    - Alternatives: What we considered
+
+**Existing ADRs:**
+- `docs/adr/ADR-001-simulation-type-registration.md` - Multi-simulation architecture
 
 ## Performance Guidelines
 
@@ -443,8 +578,9 @@ Before requesting review:
 ## Questions?
 
 If architectural decision unclear:
-1. Check `.docs/townhall-product/architecture-decision-multi-interface.md`
-2. Check existing code patterns
-3. Ask before implementing if still unclear
+1. Check `docs/adr/` for Architecture Decision Records
+2. Check `docs/architecture.md` for hexagonal architecture overview
+3. Check existing code patterns in the relevant layer
+4. Ask before implementing if still unclear
 
 **Remember: Bad architecture is technical debt. Get it right the first time.**

--- a/docs/adr/ADR-001-simulation-type-registration.md
+++ b/docs/adr/ADR-001-simulation-type-registration.md
@@ -1,0 +1,301 @@
+# ADR-001: Simulation Type Registration and Shared Utilities
+
+**Status**: Accepted
+**Date**: 2025-12-11
+**Deciders**: Project maintainers
+**Related Issues**: #16, #12, #13, #14, #15
+
+## Context
+
+Townhall needs to support multiple simulation types beyond the current debate implementation:
+
+| Simulation Type | Purpose | Example Actions |
+|-----------------|---------|-----------------|
+| Debate | Structured argumentation | Argument, Rebuttal, Concession |
+| Decision | Group decision-making | Proposal, Evaluation, Objection |
+| Brainstorm | Idea generation | Idea, BuildOn, Categorize |
+| Root Cause Analysis | Problem diagnosis | Hypothesis, Evidence, Disproof |
+
+The key architectural question: **How should simulation types be registered, and what utilities should be shared between them?**
+
+## Decision
+
+### 1. Static Registry with Plugin-Ready Design
+
+**Choice**: Option A (Static Registry) with design patterns that enable future Option C (Hybrid/Plugin)
+
+New simulation types are added to the codebase and registered explicitly at compile-time:
+
+```typescript
+// src/core/simulation/SimulationTypeRegistry.ts
+import { DebateConfig } from '../../simulations/debate';
+import { DecisionConfig } from '../../simulations/decision'; // future
+
+const registry = new SimulationTypeRegistry();
+registry.register(DebateConfig);
+// registry.register(DecisionConfig); // future
+```
+
+**Rationale**:
+- Full TypeScript type safety at compile time
+- No runtime plugin loading complexity
+- Clear, explicit registration
+- Can evolve to plugin system when external users need extensibility
+- YAGNI: We don't have external users yet
+
+### 2. Composition Over Inheritance for Shared Utilities
+
+Simulation types **compose** generic utilities from `core/` rather than inheriting from base classes.
+
+### 3. Shared Utilities Decision
+
+| Utility | Shared? | Location | Rationale |
+|---------|---------|----------|-----------|
+| **Voting** | Yes | `core/voting/` | Mechanics identical across types; only ballot shape differs |
+| **Relationships** | Yes | `core/relationships/` | Graph operations identical; only validation rules differ |
+| **Phases/Rounds** | No | Per-simulation | Semantics vary too much; abstraction too thin |
+| **Agent Roles** | No | Per-simulation | Some simulations need roles, others don't |
+
+## Architecture
+
+### Directory Structure
+
+```
+src/
+├── core/
+│   ├── simulation/              # Generic simulation interfaces
+│   │   ├── ISimulation.ts
+│   │   ├── IAction.ts
+│   │   ├── ISimulationConfig.ts
+│   │   └── SimulationTypeRegistry.ts
+│   │
+│   ├── voting/                  # SHARED: Generic voting mechanics
+│   │   ├── IVotingMechanism.ts
+│   │   ├── VoteCalculator.ts
+│   │   ├── VotingRules.ts
+│   │   └── VoteStatus.ts
+│   │
+│   ├── relationships/           # SHARED: Generic relationship graph
+│   │   ├── IRelationship.ts
+│   │   ├── RelationshipGraph.ts
+│   │   └── IRelationshipValidator.ts
+│   │
+│   └── entities/
+│       └── Agent.ts             # Agents are simulation-agnostic
+│
+├── simulations/                 # Self-contained simulation types
+│   ├── debate/
+│   │   ├── entities/
+│   │   │   ├── Argument.ts
+│   │   │   ├── Rebuttal.ts
+│   │   │   └── Concession.ts
+│   │   ├── DebateSimulation.ts
+│   │   ├── DebateConfig.ts
+│   │   ├── DebatePhase.ts
+│   │   ├── CloseVote.ts
+│   │   ├── DebateRelationshipValidator.ts
+│   │   └── index.ts
+│   │
+│   └── decision/                # Future simulation type
+│       ├── entities/
+│       ├── DecisionSimulation.ts
+│       └── ...
+│
+├── application/
+│   └── handlers/                # Handlers can be simulation-specific
+│
+└── interfaces/
+    └── cli/
+        └── commands/
+            ├── base/            # Shared commands (init, status, log)
+            └── debate/          # Debate-specific commands
+```
+
+### Shared Voting Design
+
+The voting mechanism is generic over ballot type:
+
+```typescript
+// core/voting/IVotingMechanism.ts
+interface BaseBallot {
+  readonly agentId: AgentId;
+  readonly timestamp: Timestamp;
+}
+
+interface IVotingMechanism<TBallot extends BaseBallot> {
+  recordVote(ballot: TBallot): Result<void, VotingError>;
+  hasConsensus(rules: VotingRules): boolean;
+  getVoteStatus(): VoteStatus;
+  getPendingVoters(): AgentId[];
+}
+
+// simulations/debate/CloseVote.ts
+interface CloseVote extends BaseBallot {
+  readonly vote: boolean;
+  readonly reason: string;
+}
+
+// simulations/decision/ApprovalVote.ts
+interface ApprovalVote extends BaseBallot {
+  readonly vote: boolean;
+  readonly confidence: number;
+}
+```
+
+### Shared Relationships Design
+
+The relationship graph is generic; validation rules are simulation-specific:
+
+```typescript
+// core/relationships/IRelationship.ts
+interface IRelationship<TType extends string = string> {
+  readonly fromId: ActionId;
+  readonly toIds: readonly ActionId[];  // Supports multiple targets
+  readonly type: TType;
+  readonly strength?: number;
+}
+
+// core/relationships/IRelationshipValidator.ts
+interface IRelationshipValidator<TSource, TTarget> {
+  validate(source: TSource, targets: TTarget[]): Result<void, ValidationError>;
+}
+
+// simulations/debate/DebateRelationshipValidator.ts
+class DebateRelationshipValidator implements IRelationshipValidator<Rebuttal, Argument> {
+  validate(rebuttal: Rebuttal, targets: Argument[]): Result<void, ValidationError> {
+    // Debate-specific rules:
+    // - Can't rebut own argument
+    // - Must be in same simulation
+  }
+}
+```
+
+## Boundary Rules
+
+### Rule 1: No Cross-Simulation Imports
+
+Simulation types must not import from each other:
+
+```typescript
+// NEVER: debate/ importing from decision/
+import { Proposal } from '../decision/entities/Proposal';
+
+// OK: Both import from core/
+import { IAction } from '../../core/simulation/IAction';
+```
+
+### Rule 2: Core Knows Nothing About Specific Simulations
+
+```typescript
+// NEVER: core/ importing from simulations/
+import { Argument } from '../../simulations/debate/entities/Argument';
+
+// OK: core/ defines interfaces that simulations implement
+export interface IAction { ... }
+```
+
+### Rule 3: Registration is the Only Cross-Boundary Point
+
+The `SimulationTypeRegistry` is the only place where simulation types are "known" together:
+
+```typescript
+// This is the ONLY file that imports multiple simulation configs
+import { DebateConfig } from '../../simulations/debate';
+import { DecisionConfig } from '../../simulations/decision';
+
+registry.register(DebateConfig);
+registry.register(DecisionConfig);
+```
+
+### Rule 4: Shared Utilities Use Interfaces
+
+Shared code in `core/` works with interfaces, not concrete types:
+
+```typescript
+// core/voting/VoteCalculator.ts
+class VoteCalculator {
+  // Works with any ballot type via interface
+  calculateStatus<T extends BaseBallot>(
+    ballots: T[],
+    rules: VotingRules
+  ): VoteStatus { ... }
+}
+```
+
+## Consequences
+
+### Positive
+
+1. **Type Safety**: Full compile-time type checking across all simulation types
+2. **Clear Boundaries**: Easy to understand what code belongs where
+3. **Testability**: Simulation types can be tested in isolation
+4. **Reuse Without Coupling**: Voting and relationships shared without tight coupling
+5. **Future-Proof**: Can add plugin system later without rewriting
+
+### Negative
+
+1. **Explicit Registration**: Must manually register each new simulation type
+2. **Some Duplication**: Phase logic not shared (but this is intentional)
+3. **Refactoring Required**: Current debate code needs restructuring
+
+### Neutral
+
+1. **Learning Curve**: Developers must understand composition pattern
+2. **More Files**: Separation creates more, smaller files
+
+## Alternatives Considered
+
+### Option B: Plugin System (Runtime)
+
+External packages register simulation types at runtime.
+
+**Rejected because**: Adds complexity we don't need yet. No external users requiring extensibility.
+
+### Option C: Hybrid (Static Core + Plugins)
+
+Core types compiled in, custom types via plugins.
+
+**Deferred to**: Future consideration when we have external users.
+
+### Option D: Convention-Based (Directory Scanning)
+
+Auto-discover simulation types from directory structure.
+
+**Rejected because**: "Magic" behavior makes debugging harder; TypeScript inference challenges.
+
+### Inheritance-Based Sharing
+
+Base classes like `BaseSimulation` with template methods.
+
+**Rejected because**: Creates tight coupling; harder to compose behaviors; violates project's preference for composition.
+
+## Implementation Plan
+
+### Phase 1: Extract Interfaces (Sprint 2, Issue #12)
+1. Create `ISimulation<TConfig, TStatus>` interface
+2. Create `IAction` interface
+3. Create `SimulationTypeRegistry`
+4. Refactor `DebateSimulation` to implement interfaces
+
+### Phase 2: Extract Shared Utilities
+1. Generalize `VoteCalculator` to work with any ballot type
+2. Extract `RelationshipGraph` from `RelationshipBuilder`
+3. Create validation interfaces
+
+### Phase 3: Reorganize Directory Structure
+1. Move debate code to `simulations/debate/`
+2. Create `core/voting/` and `core/relationships/`
+3. Update imports throughout codebase
+
+### Phase 4: Implement Second Simulation Type
+1. Create `simulations/decision/` following established pattern
+2. Validate that shared utilities work correctly
+3. Ensure no cross-simulation coupling
+
+## References
+
+- Issue #16: Design Decision discussion
+- Issue #12: Extract generic Simulation base
+- Issue #13: Create generic Action system
+- `/docs/architecture.md`: Hexagonal architecture overview
+- `/.docs/product/vision-overview.md`: Product roadmap with simulation types

--- a/src/core/relationships/IRelationship.ts
+++ b/src/core/relationships/IRelationship.ts
@@ -1,0 +1,104 @@
+/**
+ * ARCHITECTURE: Generic interface for relationships between actions
+ * Pattern: Interface with type parameter for relationship type
+ * Rationale: Enables different relationship types across simulations
+ *
+ * Examples of relationships:
+ * - Debate: Rebuttal "rebuts" Argument, Concession "concedes_to" Argument
+ * - Decision: Objection "objects_to" Proposal
+ * - Brainstorm: Idea "builds_on" Idea, Categorization "groups" Ideas
+ */
+
+import type { ActionId } from '../simulation/IAction';
+
+/**
+ * Generic relationship between actions.
+ *
+ * @typeParam TType - String literal union of relationship types
+ *
+ * @example
+ * ```typescript
+ * // Debate relationships
+ * type DebateRelationType = 'rebuts' | 'concedes_to' | 'supports';
+ * const rebuttal: IRelationship<DebateRelationType> = {
+ *   fromId: rebuttalId,
+ *   toIds: [argumentId],
+ *   type: 'rebuts',
+ *   strength: 0.8,
+ * };
+ *
+ * // Brainstorm relationships (can target multiple)
+ * type BrainstormRelationType = 'builds_on' | 'combines';
+ * const combination: IRelationship<BrainstormRelationType> = {
+ *   fromId: newIdeaId,
+ *   toIds: [idea1Id, idea2Id],
+ *   type: 'combines',
+ * };
+ * ```
+ */
+export interface IRelationship<TType extends string = string> {
+  /** ID of the source action (the one creating the relationship) */
+  readonly fromId: ActionId;
+
+  /**
+   * IDs of target action(s).
+   * Array to support relationships that target multiple actions
+   * (e.g., combining multiple ideas into one).
+   */
+  readonly toIds: readonly ActionId[];
+
+  /** Type of relationship */
+  readonly type: TType;
+
+  /**
+   * Optional strength/weight of the relationship (0-1).
+   * Interpretation depends on relationship type.
+   */
+  readonly strength?: number;
+
+  /**
+   * Optional metadata specific to this relationship.
+   * Simulation types can store type-specific data here.
+   */
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * Simplified relationship for single-target cases.
+ * Most relationships are single-target, so this is a convenience type.
+ */
+export interface SingleTargetRelationship<TType extends string = string> {
+  readonly fromId: ActionId;
+  readonly toId: ActionId;
+  readonly type: TType;
+  readonly strength?: number;
+}
+
+/**
+ * Convert a single-target relationship to the standard format.
+ */
+export function toRelationship<TType extends string>(
+  rel: SingleTargetRelationship<TType>
+): IRelationship<TType> {
+  return {
+    fromId: rel.fromId,
+    toIds: [rel.toId],
+    type: rel.type,
+    strength: rel.strength,
+  };
+}
+
+/**
+ * Type guard to check if an object is a relationship.
+ */
+export function isRelationship(obj: unknown): obj is IRelationship {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+  const rel = obj as Record<string, unknown>;
+  return (
+    typeof rel.fromId === 'string' &&
+    Array.isArray(rel.toIds) &&
+    typeof rel.type === 'string'
+  );
+}

--- a/src/core/relationships/IRelationship.ts
+++ b/src/core/relationships/IRelationship.ts
@@ -84,21 +84,46 @@ export function toRelationship<TType extends string>(
     fromId: rel.fromId,
     toIds: [rel.toId],
     type: rel.type,
-    strength: rel.strength,
+    ...(rel.strength !== undefined && { strength: rel.strength }),
   };
 }
 
 /**
  * Type guard to check if an object is a relationship.
+ * Validates both structure and content:
+ * - fromId must be non-empty string
+ * - toIds must be non-empty array of non-empty strings
+ * - type must be non-empty string
+ * - strength (if present) must be number between 0 and 1
  */
 export function isRelationship(obj: unknown): obj is IRelationship {
   if (typeof obj !== 'object' || obj === null) {
     return false;
   }
   const rel = obj as Record<string, unknown>;
-  return (
-    typeof rel.fromId === 'string' &&
-    Array.isArray(rel.toIds) &&
-    typeof rel.type === 'string'
-  );
+
+  // Validate required fields are non-empty strings
+  if (typeof rel.fromId !== 'string' || rel.fromId.length === 0) {
+    return false;
+  }
+  if (typeof rel.type !== 'string' || rel.type.length === 0) {
+    return false;
+  }
+
+  // Validate toIds is non-empty array of non-empty strings
+  if (!Array.isArray(rel.toIds) || rel.toIds.length === 0) {
+    return false;
+  }
+  if (!rel.toIds.every((id): id is string => typeof id === 'string' && id.length > 0)) {
+    return false;
+  }
+
+  // Validate optional strength is in valid range
+  if (rel.strength !== undefined) {
+    if (typeof rel.strength !== 'number' || rel.strength < 0 || rel.strength > 1) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/src/core/relationships/IRelationshipValidator.ts
+++ b/src/core/relationships/IRelationshipValidator.ts
@@ -1,0 +1,76 @@
+/**
+ * ARCHITECTURE: Interface for relationship validation
+ * Pattern: Strategy pattern for simulation-specific validation
+ * Rationale: Each simulation type defines its own relationship rules
+ */
+
+import type { Result } from '../../shared/result';
+import type { ValidationError } from '../../shared/errors';
+import type { IRelationship } from './IRelationship';
+
+/**
+ * Interface for validating relationships.
+ *
+ * Each simulation type implements this to enforce its rules:
+ * - Debate: Can't rebut own argument, must be in same simulation
+ * - Decision: Objections require justification
+ * - Brainstorm: Builds-on must reference existing ideas
+ *
+ * @typeParam TSource - Type of the source action
+ * @typeParam TTarget - Type of the target action(s)
+ * @typeParam TType - Relationship type string literal union
+ *
+ * @example
+ * ```typescript
+ * class DebateRelationshipValidator
+ *   implements IRelationshipValidator<Rebuttal, Argument, DebateRelationType> {
+ *
+ *   validate(
+ *     source: Rebuttal,
+ *     targets: Argument[],
+ *     type: DebateRelationType
+ *   ): Result<void, ValidationError> {
+ *     // Can't rebut own argument
+ *     if (source.agentId === targets[0].agentId) {
+ *       return err(new ValidationError('Cannot rebut own argument'));
+ *     }
+ *     return ok(undefined);
+ *   }
+ * }
+ * ```
+ */
+export interface IRelationshipValidator<
+  TSource = unknown,
+  TTarget = unknown,
+  TType extends string = string
+> {
+  /**
+   * Validate that a relationship can be created.
+   *
+   * @param source - The action creating the relationship
+   * @param targets - The action(s) being targeted
+   * @param type - Type of relationship being created
+   * @returns Result with void on success, or ValidationError
+   */
+  validate(
+    source: TSource,
+    targets: readonly TTarget[],
+    type: TType
+  ): Result<void, ValidationError>;
+}
+
+/**
+ * Context for relationship validation.
+ * Provides additional information validators might need.
+ */
+export interface RelationshipValidationContext {
+  /** ID of the simulation */
+  readonly simulationId: string;
+
+  /** All existing relationships in the simulation */
+  readonly existingRelationships: readonly IRelationship[];
+
+  /** Whether to allow relationships to closed/completed simulations */
+  readonly allowClosedSimulation: boolean;
+}
+

--- a/src/core/relationships/RelationshipGraph.ts
+++ b/src/core/relationships/RelationshipGraph.ts
@@ -1,0 +1,330 @@
+/**
+ * ARCHITECTURE: Generic graph operations for action relationships
+ * Pattern: Pure functions operating on relationship collections
+ * Rationale: Separates graph algorithms from domain-specific validation
+ *
+ * This provides reusable graph operations like:
+ * - Cycle detection
+ * - Depth calculation
+ * - Path finding
+ * - Relationship queries
+ */
+
+import { Result, ok, err } from '../../shared/result';
+import { BusinessRuleError } from '../../shared/errors';
+import type { ActionId } from '../simulation/IAction';
+import type { IRelationship } from './IRelationship';
+
+/**
+ * Result of traversing a relationship chain.
+ */
+export interface RelationshipChain<TType extends string = string> {
+  /** ID of the root action */
+  readonly rootId: ActionId;
+
+  /** All relationships in the chain */
+  readonly relationships: readonly IRelationship<TType>[];
+
+  /** Maximum depth from root */
+  readonly depth: number;
+}
+
+/**
+ * Statistics about a relationship graph.
+ */
+export interface GraphStats {
+  /** Total number of relationships */
+  readonly relationshipCount: number;
+
+  /** Number of unique actions involved */
+  readonly actionCount: number;
+
+  /** Maximum depth in the graph */
+  readonly maxDepth: number;
+
+  /** Number of root nodes (no incoming edges) */
+  readonly rootCount: number;
+
+  /** Number of leaf nodes (no outgoing edges) */
+  readonly leafCount: number;
+}
+
+/**
+ * Generic relationship graph operations.
+ *
+ * Provides pure functions for working with relationship collections.
+ * Does not store state - operates on relationship arrays passed to methods.
+ *
+ * @example
+ * ```typescript
+ * const graph = new RelationshipGraph();
+ *
+ * // Check for cycles
+ * const cycleResult = graph.detectCycles(relationships);
+ * if (cycleResult.isErr()) {
+ *   console.error('Circular reference detected!');
+ * }
+ *
+ * // Find all relationships targeting an action
+ * const targeting = graph.findTargeting(actionId, relationships);
+ * ```
+ */
+export class RelationshipGraph {
+  /**
+   * Detect circular references in a relationship graph.
+   *
+   * Uses DFS to detect cycles. Returns error if cycle found.
+   *
+   * @param relationships - All relationships to check
+   * @returns Result with void if no cycles, or error describing the cycle
+   */
+  detectCycles<TType extends string>(
+    relationships: readonly IRelationship<TType>[]
+  ): Result<void, BusinessRuleError> {
+    const visited = new Set<ActionId>();
+    const recursionStack = new Set<ActionId>();
+
+    // Get all unique "from" nodes
+    const fromNodes = new Set(relationships.map(r => r.fromId));
+
+    for (const nodeId of fromNodes) {
+      if (!visited.has(nodeId)) {
+        const hasCycle = this.hasCycleDFS(
+          nodeId,
+          relationships,
+          visited,
+          recursionStack
+        );
+
+        if (hasCycle) {
+          return err(new BusinessRuleError('Circular reference detected in relationships'));
+        }
+      }
+    }
+
+    return ok(undefined);
+  }
+
+  /**
+   * Find all relationships where the given action is a target.
+   *
+   * @param actionId - The action being targeted
+   * @param relationships - All relationships to search
+   * @returns Relationships where actionId is in toIds
+   */
+  findTargeting<TType extends string>(
+    actionId: ActionId,
+    relationships: readonly IRelationship<TType>[]
+  ): IRelationship<TType>[] {
+    return relationships.filter(r => r.toIds.includes(actionId));
+  }
+
+  /**
+   * Find all relationships from a given action.
+   *
+   * @param actionId - The source action
+   * @param relationships - All relationships to search
+   * @returns Relationships where actionId is fromId
+   */
+  findFrom<TType extends string>(
+    actionId: ActionId,
+    relationships: readonly IRelationship<TType>[]
+  ): IRelationship<TType>[] {
+    return relationships.filter(r => r.fromId === actionId);
+  }
+
+  /**
+   * Find all relationships involving a given action (as source or target).
+   *
+   * @param actionId - The action to find relationships for
+   * @param relationships - All relationships to search
+   * @returns All relationships involving actionId
+   */
+  findInvolving<TType extends string>(
+    actionId: ActionId,
+    relationships: readonly IRelationship<TType>[]
+  ): IRelationship<TType>[] {
+    return relationships.filter(
+      r => r.fromId === actionId || r.toIds.includes(actionId)
+    );
+  }
+
+  /**
+   * Find relationships of a specific type.
+   *
+   * @param type - The relationship type to find
+   * @param relationships - All relationships to search
+   * @returns Relationships of the specified type
+   */
+  findByType<TType extends string>(
+    type: TType,
+    relationships: readonly IRelationship<TType>[]
+  ): IRelationship<TType>[] {
+    return relationships.filter(r => r.type === type);
+  }
+
+  /**
+   * Build a chain of relationships starting from a root action.
+   *
+   * Traverses the graph from rootId, collecting all reachable relationships.
+   *
+   * @param rootId - Starting action ID
+   * @param relationships - All relationships
+   * @returns Chain with all connected relationships and depth
+   */
+  buildChain<TType extends string>(
+    rootId: ActionId,
+    relationships: readonly IRelationship<TType>[]
+  ): RelationshipChain<TType> {
+    const chainRelationships: IRelationship<TType>[] = [];
+    const visited = new Set<ActionId>();
+
+    this.traverseChain(rootId, relationships, chainRelationships, visited);
+
+    return {
+      rootId,
+      relationships: chainRelationships,
+      depth: this.calculateDepth(chainRelationships),
+    };
+  }
+
+  /**
+   * Calculate the maximum depth of a relationship graph.
+   *
+   * @param relationships - Relationships to analyze
+   * @returns Maximum depth (longest path)
+   */
+  calculateDepth<TType extends string>(
+    relationships: readonly IRelationship<TType>[]
+  ): number {
+    if (relationships.length === 0) {
+      return 0;
+    }
+
+    const depthMap = new Map<ActionId, number>();
+
+    for (const rel of relationships) {
+      const currentDepth = depthMap.get(rel.fromId) ?? 0;
+      const newDepth = currentDepth + 1;
+
+      for (const toId of rel.toIds) {
+        const existingDepth = depthMap.get(toId) ?? 0;
+        if (newDepth > existingDepth) {
+          depthMap.set(toId, newDepth);
+        }
+      }
+    }
+
+    return depthMap.size > 0 ? Math.max(...Array.from(depthMap.values())) : 0;
+  }
+
+  /**
+   * Get statistics about a relationship graph.
+   *
+   * @param relationships - Relationships to analyze
+   * @returns Graph statistics
+   */
+  getStats<TType extends string>(
+    relationships: readonly IRelationship<TType>[]
+  ): GraphStats {
+    const fromIds = new Set(relationships.map(r => r.fromId));
+    const toIds = new Set(relationships.flatMap(r => r.toIds));
+    const allIds = new Set([...fromIds, ...toIds]);
+
+    // Roots: have outgoing but no incoming
+    const rootCount = [...fromIds].filter(id => !toIds.has(id)).length;
+
+    // Leaves: have incoming but no outgoing
+    const leafCount = [...toIds].filter(id => !fromIds.has(id)).length;
+
+    return {
+      relationshipCount: relationships.length,
+      actionCount: allIds.size,
+      maxDepth: this.calculateDepth(relationships),
+      rootCount,
+      leafCount,
+    };
+  }
+
+  /**
+   * Find all root actions (actions with no incoming relationships).
+   *
+   * @param relationships - All relationships
+   * @returns Action IDs that are roots
+   */
+  findRoots<TType extends string>(
+    relationships: readonly IRelationship<TType>[]
+  ): ActionId[] {
+    const fromIds = new Set(relationships.map(r => r.fromId));
+    const toIds = new Set(relationships.flatMap(r => r.toIds));
+
+    return [...fromIds].filter(id => !toIds.has(id));
+  }
+
+  /**
+   * Find all leaf actions (actions with no outgoing relationships).
+   *
+   * @param relationships - All relationships
+   * @returns Action IDs that are leaves
+   */
+  findLeaves<TType extends string>(
+    relationships: readonly IRelationship<TType>[]
+  ): ActionId[] {
+    const fromIds = new Set(relationships.map(r => r.fromId));
+    const toIds = new Set(relationships.flatMap(r => r.toIds));
+
+    return [...toIds].filter(id => !fromIds.has(id));
+  }
+
+  // Private helper methods
+
+  private hasCycleDFS<TType extends string>(
+    nodeId: ActionId,
+    relationships: readonly IRelationship<TType>[],
+    visited: Set<ActionId>,
+    recursionStack: Set<ActionId>
+  ): boolean {
+    visited.add(nodeId);
+    recursionStack.add(nodeId);
+
+    // Find all adjacent nodes
+    const adjacentNodes = relationships
+      .filter(r => r.fromId === nodeId)
+      .flatMap(r => r.toIds);
+
+    for (const adjacentId of adjacentNodes) {
+      if (!visited.has(adjacentId)) {
+        if (this.hasCycleDFS(adjacentId, relationships, visited, recursionStack)) {
+          return true;
+        }
+      } else if (recursionStack.has(adjacentId)) {
+        return true; // Found a cycle
+      }
+    }
+
+    recursionStack.delete(nodeId);
+    return false;
+  }
+
+  private traverseChain<TType extends string>(
+    currentId: ActionId,
+    relationships: readonly IRelationship<TType>[],
+    chain: IRelationship<TType>[],
+    visited: Set<ActionId>
+  ): void {
+    if (visited.has(currentId)) {
+      return;
+    }
+
+    visited.add(currentId);
+
+    const outgoing = relationships.filter(r => r.fromId === currentId);
+
+    for (const rel of outgoing) {
+      chain.push(rel);
+      for (const toId of rel.toIds) {
+        this.traverseChain(toId, relationships, chain, visited);
+      }
+    }
+  }
+}

--- a/src/core/relationships/RelationshipGraph.ts
+++ b/src/core/relationships/RelationshipGraph.ts
@@ -16,6 +16,25 @@ import type { ActionId } from '../simulation/IAction';
 import type { IRelationship } from './IRelationship';
 
 /**
+ * Maximum recursion depth for graph traversal operations.
+ * Prevents stack overflow from deeply nested or malicious graphs.
+ */
+export const MAX_GRAPH_DEPTH = 1000;
+
+/**
+ * Adjacency index for efficient graph lookups.
+ * Pre-computes outgoing edges for O(1) neighbor lookup.
+ */
+export interface AdjacencyIndex<TType extends string = string> {
+  /** Map from action ID to outgoing relationships */
+  readonly outgoing: ReadonlyMap<ActionId, readonly IRelationship<TType>[]>;
+  /** Map from action ID to incoming relationships */
+  readonly incoming: ReadonlyMap<ActionId, readonly IRelationship<TType>[]>;
+  /** All unique action IDs in the graph */
+  readonly allNodes: ReadonlySet<ActionId>;
+}
+
+/**
  * Result of traversing a relationship chain.
  */
 export interface RelationshipChain<TType extends string = string> {
@@ -71,33 +90,75 @@ export interface GraphStats {
  */
 export class RelationshipGraph {
   /**
+   * Build an adjacency index for efficient graph operations.
+   *
+   * Pre-computes outgoing and incoming edges for O(1) neighbor lookup
+   * instead of O(E) filtering on each query.
+   *
+   * @param relationships - All relationships to index
+   * @returns Adjacency index for the graph
+   */
+  buildIndex<TType extends string>(
+    relationships: readonly IRelationship<TType>[]
+  ): AdjacencyIndex<TType> {
+    const outgoing = new Map<ActionId, IRelationship<TType>[]>();
+    const incoming = new Map<ActionId, IRelationship<TType>[]>();
+    const allNodes = new Set<ActionId>();
+
+    for (const rel of relationships) {
+      // Track all nodes
+      allNodes.add(rel.fromId);
+      for (const toId of rel.toIds) {
+        allNodes.add(toId);
+      }
+
+      // Build outgoing index
+      const existingOutgoing = outgoing.get(rel.fromId) ?? [];
+      existingOutgoing.push(rel);
+      outgoing.set(rel.fromId, existingOutgoing);
+
+      // Build incoming index
+      for (const toId of rel.toIds) {
+        const existingIncoming = incoming.get(toId) ?? [];
+        existingIncoming.push(rel);
+        incoming.set(toId, existingIncoming);
+      }
+    }
+
+    return { outgoing, incoming, allNodes };
+  }
+
+  /**
    * Detect circular references in a relationship graph.
    *
    * Uses DFS to detect cycles. Returns error if cycle found.
+   * Includes depth limiting to prevent stack overflow on malicious input.
    *
    * @param relationships - All relationships to check
+   * @param maxDepth - Maximum recursion depth (default: MAX_GRAPH_DEPTH)
    * @returns Result with void if no cycles, or error describing the cycle
    */
   detectCycles<TType extends string>(
-    relationships: readonly IRelationship<TType>[]
+    relationships: readonly IRelationship<TType>[],
+    maxDepth: number = MAX_GRAPH_DEPTH
   ): Result<void, BusinessRuleError> {
+    const index = this.buildIndex(relationships);
     const visited = new Set<ActionId>();
     const recursionStack = new Set<ActionId>();
 
-    // Get all unique "from" nodes
-    const fromNodes = new Set(relationships.map(r => r.fromId));
-
-    for (const nodeId of fromNodes) {
+    for (const nodeId of index.allNodes) {
       if (!visited.has(nodeId)) {
-        const hasCycle = this.hasCycleDFS(
+        const result = this.hasCycleDFSWithIndex(
           nodeId,
-          relationships,
+          index,
           visited,
-          recursionStack
+          recursionStack,
+          0,
+          maxDepth
         );
 
-        if (hasCycle) {
-          return err(new BusinessRuleError('Circular reference detected in relationships'));
+        if (result.isErr()) {
+          return result;
         }
       }
     }
@@ -167,19 +228,23 @@ export class RelationshipGraph {
    * Build a chain of relationships starting from a root action.
    *
    * Traverses the graph from rootId, collecting all reachable relationships.
+   * Includes depth limiting to prevent stack overflow.
    *
    * @param rootId - Starting action ID
    * @param relationships - All relationships
+   * @param maxDepth - Maximum traversal depth (default: MAX_GRAPH_DEPTH)
    * @returns Chain with all connected relationships and depth
    */
   buildChain<TType extends string>(
     rootId: ActionId,
-    relationships: readonly IRelationship<TType>[]
+    relationships: readonly IRelationship<TType>[],
+    maxDepth: number = MAX_GRAPH_DEPTH
   ): RelationshipChain<TType> {
+    const index = this.buildIndex(relationships);
     const chainRelationships: IRelationship<TType>[] = [];
     const visited = new Set<ActionId>();
 
-    this.traverseChain(rootId, relationships, chainRelationships, visited);
+    this.traverseChainWithIndex(rootId, index, chainRelationships, visited, 0, maxDepth);
 
     return {
       rootId,
@@ -191,8 +256,11 @@ export class RelationshipGraph {
   /**
    * Calculate the maximum depth of a relationship graph.
    *
+   * Uses topological ordering to correctly compute longest path,
+   * handling graphs where edges aren't in traversal order.
+   *
    * @param relationships - Relationships to analyze
-   * @returns Maximum depth (longest path)
+   * @returns Maximum depth (longest path from any root to any leaf)
    */
   calculateDepth<TType extends string>(
     relationships: readonly IRelationship<TType>[]
@@ -201,16 +269,51 @@ export class RelationshipGraph {
       return 0;
     }
 
+    const index = this.buildIndex(relationships);
     const depthMap = new Map<ActionId, number>();
 
-    for (const rel of relationships) {
-      const currentDepth = depthMap.get(rel.fromId) ?? 0;
-      const newDepth = currentDepth + 1;
+    // Find roots (nodes with no incoming edges)
+    const roots: ActionId[] = [];
+    for (const nodeId of index.allNodes) {
+      if (!index.incoming.has(nodeId) || index.incoming.get(nodeId)!.length === 0) {
+        roots.push(nodeId);
+        depthMap.set(nodeId, 0);
+      }
+    }
 
-      for (const toId of rel.toIds) {
-        const existingDepth = depthMap.get(toId) ?? 0;
-        if (newDepth > existingDepth) {
-          depthMap.set(toId, newDepth);
+    // If no roots found (all nodes have incoming edges = cycle), return 0
+    if (roots.length === 0) {
+      return 0;
+    }
+
+    // BFS from roots to compute depths correctly
+    const queue: ActionId[] = [...roots];
+    const processed = new Set<ActionId>();
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+
+      if (processed.has(current)) {
+        continue;
+      }
+      processed.add(current);
+
+      const currentDepth = depthMap.get(current) ?? 0;
+      const outgoingRels = index.outgoing.get(current) ?? [];
+
+      for (const rel of outgoingRels) {
+        for (const toId of rel.toIds) {
+          const existingDepth = depthMap.get(toId) ?? -1;
+          const newDepth = currentDepth + 1;
+
+          if (newDepth > existingDepth) {
+            depthMap.set(toId, newDepth);
+          }
+
+          // Only add to queue if not already processed
+          if (!processed.has(toId)) {
+            queue.push(toId);
+          }
         }
       }
     }
@@ -278,52 +381,78 @@ export class RelationshipGraph {
 
   // Private helper methods
 
-  private hasCycleDFS<TType extends string>(
+  /**
+   * DFS cycle detection using adjacency index with depth limiting.
+   */
+  private hasCycleDFSWithIndex<TType extends string>(
     nodeId: ActionId,
-    relationships: readonly IRelationship<TType>[],
+    index: AdjacencyIndex<TType>,
     visited: Set<ActionId>,
-    recursionStack: Set<ActionId>
-  ): boolean {
+    recursionStack: Set<ActionId>,
+    currentDepth: number,
+    maxDepth: number
+  ): Result<void, BusinessRuleError> {
+    // Check depth limit
+    if (currentDepth > maxDepth) {
+      return err(new BusinessRuleError(
+        `Graph traversal exceeded maximum depth of ${maxDepth}. ` +
+        `This may indicate a very deep graph or potential security issue.`
+      ));
+    }
+
     visited.add(nodeId);
     recursionStack.add(nodeId);
 
-    // Find all adjacent nodes
-    const adjacentNodes = relationships
-      .filter(r => r.fromId === nodeId)
-      .flatMap(r => r.toIds);
+    // Get adjacent nodes from index (O(1) instead of O(E))
+    const outgoingRels = index.outgoing.get(nodeId) ?? [];
+    const adjacentNodes = outgoingRels.flatMap(r => r.toIds);
 
     for (const adjacentId of adjacentNodes) {
       if (!visited.has(adjacentId)) {
-        if (this.hasCycleDFS(adjacentId, relationships, visited, recursionStack)) {
-          return true;
+        const result = this.hasCycleDFSWithIndex(
+          adjacentId,
+          index,
+          visited,
+          recursionStack,
+          currentDepth + 1,
+          maxDepth
+        );
+        if (result.isErr()) {
+          return result;
         }
       } else if (recursionStack.has(adjacentId)) {
-        return true; // Found a cycle
+        return err(new BusinessRuleError('Circular reference detected in relationships'));
       }
     }
 
     recursionStack.delete(nodeId);
-    return false;
+    return ok(undefined);
   }
 
-  private traverseChain<TType extends string>(
+  /**
+   * Chain traversal using adjacency index with depth limiting.
+   */
+  private traverseChainWithIndex<TType extends string>(
     currentId: ActionId,
-    relationships: readonly IRelationship<TType>[],
+    index: AdjacencyIndex<TType>,
     chain: IRelationship<TType>[],
-    visited: Set<ActionId>
+    visited: Set<ActionId>,
+    currentDepth: number,
+    maxDepth: number
   ): void {
-    if (visited.has(currentId)) {
+    // Check depth limit - silently stop if exceeded
+    if (currentDepth > maxDepth || visited.has(currentId)) {
       return;
     }
 
     visited.add(currentId);
 
-    const outgoing = relationships.filter(r => r.fromId === currentId);
+    const outgoingRels = index.outgoing.get(currentId) ?? [];
 
-    for (const rel of outgoing) {
+    for (const rel of outgoingRels) {
       chain.push(rel);
       for (const toId of rel.toIds) {
-        this.traverseChain(toId, relationships, chain, visited);
+        this.traverseChainWithIndex(toId, index, chain, visited, currentDepth + 1, maxDepth);
       }
     }
   }

--- a/src/core/relationships/index.ts
+++ b/src/core/relationships/index.ts
@@ -29,4 +29,6 @@ export {
   RelationshipGraph,
   RelationshipChain,
   GraphStats,
+  AdjacencyIndex,
+  MAX_GRAPH_DEPTH,
 } from './RelationshipGraph';

--- a/src/core/relationships/index.ts
+++ b/src/core/relationships/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Generic relationship mechanics for all simulation types.
+ *
+ * This module provides the shared foundation for relationships:
+ * - IRelationship: Generic interface for action relationships
+ * - IRelationshipValidator: Strategy pattern for validation
+ * - RelationshipGraph: Pure graph operations (cycles, depth, queries)
+ *
+ * Simulation types define their own relationship types as string unions
+ * (e.g., DebateRelationType = 'rebuts' | 'concedes_to' | 'supports').
+ */
+
+// Core relationship interface
+export {
+  IRelationship,
+  SingleTargetRelationship,
+  toRelationship,
+  isRelationship,
+} from './IRelationship';
+
+// Validation interface
+export {
+  IRelationshipValidator,
+  RelationshipValidationContext,
+} from './IRelationshipValidator';
+
+// Graph operations
+export {
+  RelationshipGraph,
+  RelationshipChain,
+  GraphStats,
+} from './RelationshipGraph';

--- a/src/core/simulation/IAction.ts
+++ b/src/core/simulation/IAction.ts
@@ -9,16 +9,17 @@
  * - Brainstorm: Idea, BuildOn, Categorize
  */
 
+import type { Brand } from '../../shared/types';
 import type { AgentId } from '../value-objects/AgentId';
 import type { SimulationId } from '../value-objects/SimulationId';
 import type { Timestamp } from '../value-objects/Timestamp';
 
 /**
  * Content-addressed action ID (SHA-256 hash).
- * This is a type alias that can be used for any action type.
- * Specific simulations may brand this further (e.g., ArgumentId).
+ * Branded type prevents accidental mixing with other string identifiers.
+ * Specific simulations may create narrower subtypes (e.g., ArgumentId).
  */
-export type ActionId = string;
+export type ActionId = Brand<string, 'ActionId'>;
 
 /**
  * Base interface that all actions must implement.
@@ -71,21 +72,47 @@ export interface IAction {
 }
 
 /**
- * Type guard to check if an object implements IAction
+ * Type guard to check if an object implements IAction.
+ * Validates both structure and content:
+ * - id, simulationId, agentId, actionType must be non-empty strings
+ * - timestamp must be a valid ISO date string
+ * - content must be a string (can be empty for some action types)
  */
 export function isAction(obj: unknown): obj is IAction {
   if (typeof obj !== 'object' || obj === null) {
     return false;
   }
   const action = obj as Record<string, unknown>;
-  return (
-    typeof action.id === 'string' &&
-    typeof action.simulationId === 'string' &&
-    typeof action.agentId === 'string' &&
-    typeof action.timestamp === 'string' &&
-    typeof action.actionType === 'string' &&
-    typeof action.content === 'string'
-  );
+
+  // Validate required identifier fields are non-empty strings
+  if (typeof action.id !== 'string' || action.id.length === 0) {
+    return false;
+  }
+  if (typeof action.simulationId !== 'string' || action.simulationId.length === 0) {
+    return false;
+  }
+  if (typeof action.agentId !== 'string' || action.agentId.length === 0) {
+    return false;
+  }
+  if (typeof action.actionType !== 'string' || action.actionType.length === 0) {
+    return false;
+  }
+
+  // Validate timestamp is a valid ISO date string
+  if (typeof action.timestamp !== 'string' || action.timestamp.length === 0) {
+    return false;
+  }
+  const parsedDate = Date.parse(action.timestamp);
+  if (isNaN(parsedDate)) {
+    return false;
+  }
+
+  // Content must be a string (can be empty for some action types)
+  if (typeof action.content !== 'string') {
+    return false;
+  }
+
+  return true;
 }
 
 /**

--- a/src/core/simulation/IAction.ts
+++ b/src/core/simulation/IAction.ts
@@ -1,0 +1,101 @@
+/**
+ * ARCHITECTURE: Generic interface for all action types across simulations
+ * Pattern: Interface with discriminator for type-safe pattern matching
+ * Rationale: Enables polymorphic handling of actions (Argument, Proposal, Idea, etc.)
+ *
+ * Each simulation type defines its own action types that implement this interface:
+ * - Debate: Argument, Rebuttal, Concession
+ * - Decision: Proposal, Evaluation, Objection
+ * - Brainstorm: Idea, BuildOn, Categorize
+ */
+
+import type { AgentId } from '../value-objects/AgentId';
+import type { SimulationId } from '../value-objects/SimulationId';
+import type { Timestamp } from '../value-objects/Timestamp';
+
+/**
+ * Content-addressed action ID (SHA-256 hash).
+ * This is a type alias that can be used for any action type.
+ * Specific simulations may brand this further (e.g., ArgumentId).
+ */
+export type ActionId = string;
+
+/**
+ * Base interface that all actions must implement.
+ *
+ * Actions are the atomic units of participation in a simulation.
+ * They are immutable, content-addressed, and linked to an agent.
+ *
+ * @example
+ * ```typescript
+ * // Debate's Argument implements IAction
+ * class Argument implements IAction {
+ *   readonly actionType = 'argument';
+ *   // ... debate-specific fields
+ * }
+ *
+ * // Decision's Proposal implements IAction
+ * class Proposal implements IAction {
+ *   readonly actionType = 'proposal';
+ *   // ... decision-specific fields
+ * }
+ * ```
+ */
+export interface IAction {
+  /** Content-addressed unique identifier (SHA-256 hash) */
+  readonly id: ActionId;
+
+  /** Simulation this action belongs to */
+  readonly simulationId: SimulationId;
+
+  /** Agent who created this action */
+  readonly agentId: AgentId;
+
+  /** When the action was created */
+  readonly timestamp: Timestamp;
+
+  /**
+   * Discriminator for type narrowing.
+   * Each action type has a unique string value.
+   *
+   * @example 'argument' | 'rebuttal' | 'concession' for debate
+   * @example 'proposal' | 'evaluation' | 'objection' for decision
+   */
+  readonly actionType: string;
+
+  /**
+   * Human-readable content of the action.
+   * The interpretation depends on the action type.
+   */
+  readonly content: string;
+}
+
+/**
+ * Type guard to check if an object implements IAction
+ */
+export function isAction(obj: unknown): obj is IAction {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+  const action = obj as Record<string, unknown>;
+  return (
+    typeof action.id === 'string' &&
+    typeof action.simulationId === 'string' &&
+    typeof action.agentId === 'string' &&
+    typeof action.timestamp === 'string' &&
+    typeof action.actionType === 'string' &&
+    typeof action.content === 'string'
+  );
+}
+
+/**
+ * Minimal action data for storage/transfer.
+ * Used when full entity isn't needed.
+ */
+export interface ActionSummary {
+  readonly id: ActionId;
+  readonly actionType: string;
+  readonly agentId: AgentId;
+  readonly timestamp: Timestamp;
+  readonly contentPreview: string; // First N characters
+}

--- a/src/core/simulation/ISimulation.ts
+++ b/src/core/simulation/ISimulation.ts
@@ -1,0 +1,67 @@
+/**
+ * ARCHITECTURE: Generic interface for all simulation types
+ * Pattern: Interface with type parameters for config and status
+ * Rationale: Enables type-safe polymorphism across simulation types
+ *
+ * Simulation types (debate, decision, brainstorm) implement this interface
+ * with their own config and status types.
+ */
+
+import type { SimulationId } from '../value-objects/SimulationId';
+import type { AgentId } from '../value-objects/AgentId';
+import type { Timestamp } from '../value-objects/Timestamp';
+import type { SimulationType } from './SimulationType';
+
+/**
+ * Base interface that all simulations must implement.
+ *
+ * @typeParam TConfig - Simulation-specific configuration type
+ * @typeParam TStatus - Simulation-specific status enum/union type
+ *
+ * @example
+ * ```typescript
+ * // Debate simulation implements with specific types
+ * class DebateSimulation implements ISimulation<DebateConfig, DebateStatus> {
+ *   readonly type = SimulationTypeFactory.DEBATE;
+ *   // ...
+ * }
+ * ```
+ */
+export interface ISimulation<
+  TConfig = unknown,
+  TStatus extends string = string
+> {
+  /** Unique content-addressed identifier */
+  readonly id: SimulationId;
+
+  /** Discriminator for simulation type (e.g., 'debate', 'decision') */
+  readonly type: SimulationType;
+
+  /** Human-readable topic or title */
+  readonly topic: string;
+
+  /** Current status (type-specific enum) */
+  readonly status: TStatus;
+
+  /** When the simulation was created */
+  readonly createdAt: Timestamp;
+
+  /** Agents participating in this simulation */
+  readonly participantIds: readonly AgentId[];
+
+  /** Type-specific configuration */
+  readonly config: TConfig;
+}
+
+/**
+ * Minimal simulation data for storage/transfer.
+ * Used when full entity isn't needed.
+ */
+export interface SimulationSummary {
+  readonly id: SimulationId;
+  readonly type: SimulationType;
+  readonly topic: string;
+  readonly status: string;
+  readonly createdAt: Timestamp;
+  readonly participantCount: number;
+}

--- a/src/core/simulation/ISimulationConfig.ts
+++ b/src/core/simulation/ISimulationConfig.ts
@@ -1,0 +1,90 @@
+/**
+ * ARCHITECTURE: Configuration interface for simulation type registration
+ * Pattern: Factory pattern with metadata for registration
+ * Rationale: Enables registry to create simulations without knowing concrete types
+ */
+
+import type { Result } from '../../shared/result';
+import type { ValidationError } from '../../shared/errors';
+import type { SimulationType } from './SimulationType';
+import type { ISimulation } from './ISimulation';
+
+/**
+ * Configuration for registering a simulation type with the registry.
+ *
+ * Each simulation type (debate, decision, brainstorm) provides a config
+ * that tells the registry how to create and identify simulations of that type.
+ *
+ * @typeParam TSimulation - The concrete simulation type
+ * @typeParam TConfig - The simulation's configuration type
+ * @typeParam TStatus - The simulation's status enum type
+ *
+ * @example
+ * ```typescript
+ * const DebateSimulationConfig: ISimulationTypeConfig<DebateSimulation, DebateConfig, DebateStatus> = {
+ *   type: SimulationTypeFactory.DEBATE,
+ *   name: 'Debate',
+ *   description: 'Structured argumentation with rebuttals and concessions',
+ *   actionTypes: ['argument', 'rebuttal', 'concession'],
+ *   // ...
+ * };
+ * ```
+ */
+export interface ISimulationTypeConfig<
+  TSimulation extends ISimulation<TConfig, TStatus>,
+  TConfig = unknown,
+  TStatus extends string = string
+> {
+  /** Unique type identifier */
+  readonly type: SimulationType;
+
+  /** Human-readable name for display */
+  readonly name: string;
+
+  /** Description of what this simulation type is for */
+  readonly description: string;
+
+  /** Action types supported by this simulation (e.g., ['argument', 'rebuttal', 'concession']) */
+  readonly actionTypes: readonly string[];
+
+  /**
+   * Factory method to create a new simulation instance.
+   * The registry calls this when a user creates a new simulation of this type.
+   */
+  create(params: SimulationCreateParams<TConfig>): Result<TSimulation, ValidationError>;
+
+  /**
+   * Validate that a configuration object is valid for this simulation type.
+   */
+  validateConfig(config: unknown): Result<TConfig, ValidationError>;
+}
+
+/**
+ * Parameters passed to simulation factory methods
+ */
+export interface SimulationCreateParams<TConfig = unknown> {
+  /** Topic or title for the simulation */
+  readonly topic: string;
+
+  /** Type-specific configuration */
+  readonly config: TConfig;
+
+  /** Creation timestamp */
+  readonly createdAt: string; // ISO timestamp
+
+  /** Crypto service for ID generation (injected) */
+  readonly cryptoService: {
+    hash(content: string, algorithm: string): string;
+  };
+}
+
+/**
+ * Simplified config interface for runtime registration
+ * (when full generics aren't needed)
+ */
+export interface SimulationTypeInfo {
+  readonly type: SimulationType;
+  readonly name: string;
+  readonly description: string;
+  readonly actionTypes: readonly string[];
+}

--- a/src/core/simulation/SimulationType.ts
+++ b/src/core/simulation/SimulationType.ts
@@ -1,0 +1,44 @@
+/**
+ * ARCHITECTURE: Value object for simulation type identification
+ * Pattern: Branded type with extensible union
+ * Rationale: Type-safe discrimination of simulation types
+ */
+
+import { Brand } from '../../shared/types';
+
+/**
+ * Known simulation types in the system.
+ * New types are added here as they are implemented.
+ */
+export type SimulationTypeName = 'debate' | 'decision' | 'brainstorm';
+
+/**
+ * Branded type for simulation type to prevent string confusion
+ */
+export type SimulationType = Brand<SimulationTypeName, 'SimulationType'>;
+
+/**
+ * Factory for creating SimulationType values
+ */
+export const SimulationTypeFactory = {
+  /**
+   * Create a SimulationType from a known type name
+   */
+  create(name: SimulationTypeName): SimulationType {
+    return name as SimulationType;
+  },
+
+  /**
+   * Check if a string is a valid simulation type
+   */
+  isValid(value: string): value is SimulationTypeName {
+    return ['debate', 'decision', 'brainstorm'].includes(value);
+  },
+
+  /**
+   * Pre-defined simulation types
+   */
+  DEBATE: 'debate' as SimulationType,
+  DECISION: 'decision' as SimulationType,
+  BRAINSTORM: 'brainstorm' as SimulationType,
+} as const;

--- a/src/core/simulation/SimulationTypeRegistry.ts
+++ b/src/core/simulation/SimulationTypeRegistry.ts
@@ -1,0 +1,105 @@
+/**
+ * ARCHITECTURE: Central registry for simulation type registration
+ * Pattern: Service Locator with static registration
+ * Rationale: Single point where all simulation types are known
+ *
+ * IMPORTANT: This is the ONLY place in core/ that imports from simulations/
+ * All other core/ code works with interfaces, not concrete types.
+ */
+
+import { Result, ok, err } from '../../shared/result';
+import { ValidationError } from '../../shared/errors';
+import type { SimulationType } from './SimulationType';
+import type { SimulationTypeInfo } from './ISimulationConfig';
+
+/**
+ * Registry for simulation types.
+ *
+ * Simulation types register themselves at startup, providing metadata
+ * and factory functions. The registry enables:
+ * - Looking up simulation type info by type identifier
+ * - Listing all available simulation types
+ * - Validating simulation type identifiers
+ *
+ * @example
+ * ```typescript
+ * // Registration (done once at startup in simulations/)
+ * SimulationTypeRegistry.register({
+ *   type: SimulationTypeFactory.DEBATE,
+ *   name: 'Debate',
+ *   description: 'Structured argumentation',
+ *   actionTypes: ['argument', 'rebuttal', 'concession'],
+ * });
+ *
+ * // Usage
+ * const info = SimulationTypeRegistry.get('debate');
+ * const allTypes = SimulationTypeRegistry.getAll();
+ * ```
+ */
+export class SimulationTypeRegistry {
+  private static readonly types = new Map<string, SimulationTypeInfo>();
+
+  /**
+   * Register a simulation type.
+   * Called during application startup by each simulation module.
+   *
+   * @throws Error if type is already registered (prevents double registration)
+   */
+  static register(config: SimulationTypeInfo): void {
+    const typeKey = String(config.type);
+    if (this.types.has(typeKey)) {
+      throw new Error(`Simulation type '${typeKey}' is already registered`);
+    }
+    this.types.set(typeKey, config);
+  }
+
+  /**
+   * Get simulation type info by type identifier.
+   *
+   * @returns Result with type info or error if not found
+   */
+  static get(type: SimulationType | string): Result<SimulationTypeInfo, ValidationError> {
+    const typeKey = String(type);
+    const info = this.types.get(typeKey);
+    if (!info) {
+      return err(new ValidationError(`Unknown simulation type: '${typeKey}'`));
+    }
+    return ok(info);
+  }
+
+  /**
+   * Check if a simulation type is registered.
+   */
+  static has(type: SimulationType | string): boolean {
+    return this.types.has(String(type));
+  }
+
+  /**
+   * Get all registered simulation types.
+   */
+  static getAll(): readonly SimulationTypeInfo[] {
+    return Array.from(this.types.values());
+  }
+
+  /**
+   * Get all registered type identifiers.
+   */
+  static getTypeNames(): readonly string[] {
+    return Array.from(this.types.keys());
+  }
+
+  /**
+   * Clear all registrations.
+   * Primarily for testing - allows resetting registry state.
+   */
+  static clear(): void {
+    this.types.clear();
+  }
+
+  /**
+   * Get count of registered types.
+   */
+  static get count(): number {
+    return this.types.size;
+  }
+}

--- a/src/core/simulation/SimulationTypeRegistry.ts
+++ b/src/core/simulation/SimulationTypeRegistry.ts
@@ -43,6 +43,12 @@ export class SimulationTypeRegistry {
    * Register a simulation type.
    * Called during application startup by each simulation module.
    *
+   * ARCHITECTURE NOTE: This method intentionally throws instead of returning Result.
+   * Rationale: Registration happens at startup, not during business operations.
+   * Double-registration is a programmer error (misconfiguration), not a runtime
+   * condition. Fail-fast behavior catches configuration bugs immediately.
+   * See ADR-001 for the static registry design decision.
+   *
    * @throws Error if type is already registered (prevents double registration)
    */
   static register(config: SimulationTypeInfo): void {

--- a/src/core/simulation/index.ts
+++ b/src/core/simulation/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Core simulation interfaces and registry.
+ *
+ * This module provides the generic foundation for all simulation types.
+ * Concrete implementations live in src/simulations/<type>/
+ */
+
+// Type identification
+export { SimulationType, SimulationTypeName, SimulationTypeFactory } from './SimulationType';
+
+// Core interfaces
+export { ISimulation, SimulationSummary } from './ISimulation';
+export { IAction, ActionId, ActionSummary, isAction } from './IAction';
+export {
+  ISimulationTypeConfig,
+  SimulationCreateParams,
+  SimulationTypeInfo,
+} from './ISimulationConfig';
+
+// Registry
+export { SimulationTypeRegistry } from './SimulationTypeRegistry';

--- a/src/core/voting/BaseBallot.ts
+++ b/src/core/voting/BaseBallot.ts
@@ -1,0 +1,55 @@
+/**
+ * ARCHITECTURE: Base interface for all ballot/vote types
+ * Pattern: Minimal interface that all votes must implement
+ * Rationale: Enables generic voting calculations across simulation types
+ */
+
+import type { AgentId } from '../value-objects/AgentId';
+import type { Timestamp } from '../value-objects/Timestamp';
+
+/**
+ * Minimal interface that all ballot types must implement.
+ *
+ * Different simulation types extend this with type-specific fields:
+ * - Debate: CloseVote adds `vote: boolean` and `reason?: string`
+ * - Decision: ApprovalVote adds `vote: boolean` and `confidence: number`
+ * - Brainstorm: IdeaRating adds `ideaId: string` and `rating: 1-5`
+ *
+ * @example
+ * ```typescript
+ * // Debate's close vote
+ * interface CloseVote extends BaseBallot {
+ *   readonly vote: boolean;
+ *   readonly reason?: string;
+ * }
+ *
+ * // Decision's approval vote
+ * interface ApprovalVote extends BaseBallot {
+ *   readonly vote: boolean;
+ *   readonly confidence: number;
+ * }
+ * ```
+ */
+export interface BaseBallot {
+  /** Agent who cast this vote */
+  readonly agentId: AgentId;
+
+  /** When the vote was cast */
+  readonly timestamp: Timestamp;
+}
+
+/**
+ * Extended ballot interface for binary (yes/no) votes.
+ * Most simulation types use binary voting for decisions.
+ */
+export interface BinaryBallot extends BaseBallot {
+  /** The vote: true = yes/approve, false = no/reject */
+  readonly vote: boolean;
+}
+
+/**
+ * Type guard to check if a ballot is binary
+ */
+export function isBinaryBallot(ballot: BaseBallot): ballot is BinaryBallot {
+  return 'vote' in ballot && typeof (ballot as BinaryBallot).vote === 'boolean';
+}

--- a/src/core/voting/IVotingMechanism.ts
+++ b/src/core/voting/IVotingMechanism.ts
@@ -9,7 +9,7 @@ import type { BusinessRuleError } from '../../shared/errors';
 import type { AgentId } from '../value-objects/AgentId';
 import type { BaseBallot } from './BaseBallot';
 import type { VotingRules } from './VotingRules';
-import type { VoteStatus, VotingSummary } from './VoteStatus';
+import type { VoteStatus } from './VoteStatus';
 
 /**
  * Interface for voting mechanisms that can work with any ballot type.

--- a/src/core/voting/IVotingMechanism.ts
+++ b/src/core/voting/IVotingMechanism.ts
@@ -1,0 +1,111 @@
+/**
+ * ARCHITECTURE: Generic interface for voting mechanisms
+ * Pattern: Interface with type parameter for ballot type
+ * Rationale: Enables different ballot types with same voting logic
+ */
+
+import type { Result } from '../../shared/result';
+import type { BusinessRuleError } from '../../shared/errors';
+import type { AgentId } from '../value-objects/AgentId';
+import type { BaseBallot } from './BaseBallot';
+import type { VotingRules } from './VotingRules';
+import type { VoteStatus, VotingSummary } from './VoteStatus';
+
+/**
+ * Interface for voting mechanisms that can work with any ballot type.
+ *
+ * Simulation types compose this interface with their ballot type:
+ * - DebateSimulation uses IVotingMechanism<CloseVote>
+ * - DecisionSimulation uses IVotingMechanism<ApprovalVote>
+ *
+ * @typeParam TBallot - The specific ballot type (must extend BaseBallot)
+ *
+ * @example
+ * ```typescript
+ * // In DebateSimulation
+ * class DebateSimulation {
+ *   private voting: IVotingMechanism<CloseVote>;
+ *
+ *   recordCloseVote(vote: CloseVote) {
+ *     return this.voting.recordVote(vote);
+ *   }
+ * }
+ * ```
+ */
+export interface IVotingMechanism<TBallot extends BaseBallot> {
+  /**
+   * Record a new vote.
+   *
+   * @param ballot - The vote to record
+   * @returns Result with void on success, or error if vote is invalid
+   */
+  recordVote(ballot: TBallot): Result<void, BusinessRuleError>;
+
+  /**
+   * Check if consensus has been reached.
+   *
+   * @param rules - Voting rules to use for consensus calculation
+   * @returns true if consensus reached according to rules
+   */
+  hasConsensus(rules: VotingRules): boolean;
+
+  /**
+   * Get current voting status.
+   *
+   * @param rules - Voting rules for status calculation
+   * @returns Current vote status
+   */
+  getVoteStatus(rules: VotingRules): VoteStatus;
+
+  /**
+   * Get agents who haven't voted yet.
+   *
+   * @returns Array of agent IDs who still need to vote
+   */
+  getPendingVoters(): readonly AgentId[];
+
+  /**
+   * Get all recorded votes.
+   *
+   * @returns Array of all ballots cast
+   */
+  getVotes(): readonly TBallot[];
+
+  /**
+   * Check if an agent has already voted.
+   *
+   * @param agentId - Agent to check
+   * @returns true if agent has voted
+   */
+  hasVoted(agentId: AgentId): boolean;
+}
+
+/**
+ * Context needed for voting validation.
+ * Passed to validators to check if a vote is allowed.
+ */
+export interface VotingContext {
+  /** All participants eligible to vote */
+  readonly participantIds: readonly AgentId[];
+
+  /** Current status (may affect if voting is allowed) */
+  readonly status: string;
+
+  /** Whether voting is currently open */
+  readonly votingOpen: boolean;
+}
+
+/**
+ * Interface for vote validation logic.
+ * Simulation types can provide custom validators.
+ */
+export interface IVoteValidator<TBallot extends BaseBallot> {
+  /**
+   * Validate that a vote can be recorded.
+   *
+   * @param ballot - The vote to validate
+   * @param context - Current voting context
+   * @returns Result with void on success, or error describing why vote is invalid
+   */
+  validate(ballot: TBallot, context: VotingContext): Result<void, BusinessRuleError>;
+}

--- a/src/core/voting/VoteCalculator.ts
+++ b/src/core/voting/VoteCalculator.ts
@@ -46,9 +46,16 @@ export class GenericVoteCalculator {
     rules: VotingRules = DEFAULT_VOTING_RULES
   ): VoteStatus {
     const totalParticipants = participantIds.length;
-    const yesVotes = ballots.filter(b => b.vote).length;
-    const noVotes = ballots.filter(b => !b.vote).length;
     const totalVotes = ballots.length;
+
+    // Single-pass vote counting: O(n) instead of O(3n)
+    let yesVotes = 0;
+    for (const ballot of ballots) {
+      if (ballot.vote) {
+        yesVotes++;
+      }
+    }
+    const noVotes = totalVotes - yesVotes;
 
     const participationRate = totalParticipants > 0
       ? totalVotes / totalParticipants
@@ -93,20 +100,15 @@ export class GenericVoteCalculator {
     ballots: readonly TBallot[],
     participantIds: readonly AgentId[]
   ): VotingSummary {
-    const participants = participantIds.length;
-    const voted = ballots.length;
-    const yesVotes = ballots.filter(b => b.vote).length;
-    const noVotes = ballots.filter(b => !b.vote).length;
-
-    // Check consensus with default rules
+    // Reuse calculateStatus which already counts votes in O(n)
     const status = this.calculateStatus(ballots, participantIds);
 
     return {
-      participants,
-      voted,
-      pending: participants - voted,
-      yesVotes,
-      noVotes,
+      participants: participantIds.length,
+      voted: status.total,
+      pending: status.required - status.total,
+      yesVotes: status.yesVotes,
+      noVotes: status.noVotes,
       consensusReached: status.hasConsensus,
     };
   }
@@ -188,13 +190,21 @@ export class GenericVoteCalculator {
       ? voteTimes.reduce((sum, t) => sum + t, 0) / voteTimes.length
       : 0;
 
+    // Single-pass vote distribution counting
+    let yesCount = 0;
+    for (const ballot of ballots) {
+      if (ballot.vote) {
+        yesCount++;
+      }
+    }
+
     return {
       averageVoteTime,
       quickestVote: voteTimes.length > 0 ? Math.min(...voteTimes) : 0,
       slowestVote: voteTimes.length > 0 ? Math.max(...voteTimes) : 0,
       voteDistribution: {
-        yes: ballots.filter(b => b.vote).length,
-        no: ballots.filter(b => !b.vote).length,
+        yes: yesCount,
+        no: ballots.length - yesCount,
         abstain: 0,
       },
     };

--- a/src/core/voting/VoteCalculator.ts
+++ b/src/core/voting/VoteCalculator.ts
@@ -1,0 +1,216 @@
+/**
+ * ARCHITECTURE: Generic vote calculation service
+ * Pattern: Pure functions operating on ballot collections
+ * Rationale: Separates calculation logic from storage/entities
+ *
+ * This is a generic version that works with any BinaryBallot type.
+ * The existing VoteCalculator in services/ will be updated to use this.
+ */
+
+import type { AgentId } from '../value-objects/AgentId';
+import type { BinaryBallot } from './BaseBallot';
+import type { VotingRules } from './VotingRules';
+import type { VoteStatus, VotingSummary, VotingPatternAnalysis } from './VoteStatus';
+import { DEFAULT_VOTING_RULES } from './VotingRules';
+
+/**
+ * Generic vote calculator that works with any binary ballot type.
+ *
+ * This class provides pure calculation functions that operate on
+ * collections of ballots. It doesn't store state - that's the
+ * responsibility of the simulation or voting mechanism.
+ *
+ * @example
+ * ```typescript
+ * const calculator = new GenericVoteCalculator();
+ *
+ * const status = calculator.calculateStatus(
+ *   votes,           // CloseVote[] or ApprovalVote[]
+ *   participantIds,  // AgentId[]
+ *   rules           // VotingRules
+ * );
+ * ```
+ */
+export class GenericVoteCalculator {
+  /**
+   * Calculate voting status from a collection of ballots.
+   *
+   * @param ballots - Collection of binary votes
+   * @param participantIds - All eligible voters
+   * @param rules - Rules for consensus calculation
+   * @returns Current voting status
+   */
+  calculateStatus<TBallot extends BinaryBallot>(
+    ballots: readonly TBallot[],
+    participantIds: readonly AgentId[],
+    rules: VotingRules = DEFAULT_VOTING_RULES
+  ): VoteStatus {
+    const totalParticipants = participantIds.length;
+    const yesVotes = ballots.filter(b => b.vote).length;
+    const noVotes = ballots.filter(b => !b.vote).length;
+    const totalVotes = ballots.length;
+
+    const participationRate = totalParticipants > 0
+      ? totalVotes / totalParticipants
+      : 0;
+
+    const meetsParticipation = participationRate >= rules.minimumParticipation;
+
+    let hasConsensus = false;
+    let thresholdMet = false;
+
+    if (rules.requireUnanimity) {
+      // Unanimity: everyone must vote yes
+      hasConsensus = yesVotes === totalParticipants && totalVotes === totalParticipants;
+      thresholdMet = hasConsensus;
+    } else {
+      // Majority: 50%+1 of participants must vote yes
+      const majority = Math.floor(totalParticipants / 2) + 1;
+      hasConsensus = yesVotes >= majority && meetsParticipation;
+      thresholdMet = meetsParticipation;
+    }
+
+    return {
+      total: totalVotes,
+      required: totalParticipants,
+      yesVotes,
+      noVotes,
+      abstentions: 0, // Binary ballots don't support abstention
+      hasConsensus,
+      thresholdMet,
+      participationRate,
+    };
+  }
+
+  /**
+   * Get a summary suitable for display.
+   *
+   * @param ballots - Collection of binary votes
+   * @param participantIds - All eligible voters
+   * @returns Voting summary
+   */
+  getSummary<TBallot extends BinaryBallot>(
+    ballots: readonly TBallot[],
+    participantIds: readonly AgentId[]
+  ): VotingSummary {
+    const participants = participantIds.length;
+    const voted = ballots.length;
+    const yesVotes = ballots.filter(b => b.vote).length;
+    const noVotes = ballots.filter(b => !b.vote).length;
+
+    // Check consensus with default rules
+    const status = this.calculateStatus(ballots, participantIds);
+
+    return {
+      participants,
+      voted,
+      pending: participants - voted,
+      yesVotes,
+      noVotes,
+      consensusReached: status.hasConsensus,
+    };
+  }
+
+  /**
+   * Get agents who haven't voted yet.
+   *
+   * @param ballots - Collection of votes already cast
+   * @param participantIds - All eligible voters
+   * @returns Agent IDs who haven't voted
+   */
+  getPendingVoters<TBallot extends BinaryBallot>(
+    ballots: readonly TBallot[],
+    participantIds: readonly AgentId[]
+  ): AgentId[] {
+    const votedAgents = new Set(ballots.map(b => b.agentId));
+    return participantIds.filter(id => !votedAgents.has(id));
+  }
+
+  /**
+   * Calculate how many more yes votes are needed for consensus.
+   *
+   * @param ballots - Collection of votes already cast
+   * @param participantIds - All eligible voters
+   * @param rules - Voting rules
+   * @returns Number of yes votes needed (0 if consensus reached, -1 if impossible)
+   */
+  calculateVotesNeeded<TBallot extends BinaryBallot>(
+    ballots: readonly TBallot[],
+    participantIds: readonly AgentId[],
+    rules: VotingRules = DEFAULT_VOTING_RULES
+  ): number {
+    const status = this.calculateStatus(ballots, participantIds, rules);
+
+    if (status.hasConsensus) {
+      return 0;
+    }
+
+    // If unanimity required and there's a no vote, consensus is impossible
+    if (rules.requireUnanimity && status.noVotes > 0) {
+      return -1;
+    }
+
+    return Math.max(0, status.required - status.yesVotes);
+  }
+
+  /**
+   * Analyze voting patterns over time.
+   *
+   * @param ballots - Collection of votes with timestamps
+   * @returns Pattern analysis
+   */
+  analyzePattern<TBallot extends BinaryBallot>(
+    ballots: readonly TBallot[]
+  ): VotingPatternAnalysis {
+    if (ballots.length === 0) {
+      return {
+        averageVoteTime: 0,
+        quickestVote: 0,
+        slowestVote: 0,
+        voteDistribution: { yes: 0, no: 0, abstain: 0 },
+      };
+    }
+
+    // Sort by timestamp
+    const sorted = [...ballots].sort((a, b) =>
+      new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+
+    // Calculate time between votes
+    const voteTimes: number[] = [];
+    for (let i = 1; i < sorted.length; i++) {
+      const current = new Date(sorted[i]!.timestamp).getTime();
+      const previous = new Date(sorted[i - 1]!.timestamp).getTime();
+      voteTimes.push(current - previous);
+    }
+
+    const averageVoteTime = voteTimes.length > 0
+      ? voteTimes.reduce((sum, t) => sum + t, 0) / voteTimes.length
+      : 0;
+
+    return {
+      averageVoteTime,
+      quickestVote: voteTimes.length > 0 ? Math.min(...voteTimes) : 0,
+      slowestVote: voteTimes.length > 0 ? Math.max(...voteTimes) : 0,
+      voteDistribution: {
+        yes: ballots.filter(b => b.vote).length,
+        no: ballots.filter(b => !b.vote).length,
+        abstain: 0,
+      },
+    };
+  }
+
+  /**
+   * Check if an agent has already voted.
+   *
+   * @param agentId - Agent to check
+   * @param ballots - Collection of votes
+   * @returns true if agent has voted
+   */
+  hasVoted<TBallot extends BinaryBallot>(
+    agentId: AgentId,
+    ballots: readonly TBallot[]
+  ): boolean {
+    return ballots.some(b => b.agentId === agentId);
+  }
+}

--- a/src/core/voting/VoteStatus.ts
+++ b/src/core/voting/VoteStatus.ts
@@ -1,0 +1,79 @@
+/**
+ * ARCHITECTURE: Status information for voting progress
+ * Pattern: Value object for vote tallying results
+ * Rationale: Encapsulates all voting state information
+ */
+
+/**
+ * Current status of a voting session.
+ * Returned by VoteCalculator to report voting progress.
+ */
+export interface VoteStatus {
+  /** Total votes cast so far */
+  readonly total: number;
+
+  /** Number of participants required to vote */
+  readonly required: number;
+
+  /** Number of yes/approve votes */
+  readonly yesVotes: number;
+
+  /** Number of no/reject votes */
+  readonly noVotes: number;
+
+  /** Number of abstentions (if allowed) */
+  readonly abstentions: number;
+
+  /** Whether consensus has been reached */
+  readonly hasConsensus: boolean;
+
+  /** Whether the voting threshold has been met (may differ from consensus) */
+  readonly thresholdMet: boolean;
+
+  /** Percentage of participants who have voted (0-1) */
+  readonly participationRate: number;
+}
+
+/**
+ * Summary of voting for display purposes.
+ */
+export interface VotingSummary {
+  /** Total number of participants eligible to vote */
+  readonly participants: number;
+
+  /** Number who have voted */
+  readonly voted: number;
+
+  /** Number still to vote */
+  readonly pending: number;
+
+  /** Number of yes votes */
+  readonly yesVotes: number;
+
+  /** Number of no votes */
+  readonly noVotes: number;
+
+  /** Whether consensus has been reached */
+  readonly consensusReached: boolean;
+}
+
+/**
+ * Analysis of voting patterns over time.
+ */
+export interface VotingPatternAnalysis {
+  /** Average time between votes (ms) */
+  readonly averageVoteTime: number;
+
+  /** Shortest time between votes (ms) */
+  readonly quickestVote: number;
+
+  /** Longest time between votes (ms) */
+  readonly slowestVote: number;
+
+  /** Distribution of votes */
+  readonly voteDistribution: {
+    readonly yes: number;
+    readonly no: number;
+    readonly abstain: number;
+  };
+}

--- a/src/core/voting/VotingRules.ts
+++ b/src/core/voting/VotingRules.ts
@@ -1,0 +1,57 @@
+/**
+ * ARCHITECTURE: Configuration for voting behavior
+ * Pattern: Value object for voting rules
+ * Rationale: Separates voting policy from mechanism
+ */
+
+/**
+ * Configuration that determines how votes are counted
+ * and when consensus is reached.
+ */
+export interface VotingRules {
+  /**
+   * If true, all participants must vote yes for consensus.
+   * If false, majority (50%+1) is sufficient.
+   */
+  readonly requireUnanimity: boolean;
+
+  /**
+   * Minimum percentage of participants who must vote (0-1).
+   * E.g., 0.75 means 75% must vote before consensus can be determined.
+   */
+  readonly minimumParticipation: number;
+
+  /**
+   * If true, participants can explicitly abstain.
+   * Abstentions count toward participation but not toward yes/no.
+   */
+  readonly allowAbstention: boolean;
+}
+
+/**
+ * Default voting rules: unanimous consent with full participation.
+ */
+export const DEFAULT_VOTING_RULES: VotingRules = {
+  requireUnanimity: true,
+  minimumParticipation: 1.0,
+  allowAbstention: false,
+};
+
+/**
+ * Majority voting rules: 50%+1 with minimum 75% participation.
+ */
+export const MAJORITY_VOTING_RULES: VotingRules = {
+  requireUnanimity: false,
+  minimumParticipation: 0.75,
+  allowAbstention: true,
+};
+
+/**
+ * Validate voting rules configuration
+ */
+export function validateVotingRules(rules: VotingRules): string | null {
+  if (rules.minimumParticipation < 0 || rules.minimumParticipation > 1) {
+    return 'minimumParticipation must be between 0 and 1';
+  }
+  return null;
+}

--- a/src/core/voting/VotingRules.ts
+++ b/src/core/voting/VotingRules.ts
@@ -47,7 +47,18 @@ export const MAJORITY_VOTING_RULES: VotingRules = {
 };
 
 /**
- * Validate voting rules configuration
+ * Validate voting rules configuration.
+ *
+ * @param rules - The voting rules to validate
+ * @returns null if rules are valid, or an error message string describing the validation failure
+ *
+ * @example
+ * ```typescript
+ * const error = validateVotingRules(myRules);
+ * if (error) {
+ *   console.error(`Invalid rules: ${error}`);
+ * }
+ * ```
  */
 export function validateVotingRules(rules: VotingRules): string | null {
   if (rules.minimumParticipation < 0 || rules.minimumParticipation > 1) {

--- a/src/core/voting/index.ts
+++ b/src/core/voting/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Generic voting mechanics for all simulation types.
+ *
+ * This module provides the shared foundation for voting:
+ * - BaseBallot: Minimal interface all votes implement
+ * - VotingRules: Configuration for consensus calculation
+ * - VoteStatus: Current state of voting
+ * - GenericVoteCalculator: Pure calculation functions
+ *
+ * Simulation types extend BaseBallot with type-specific fields
+ * (e.g., CloseVote adds `reason`, ApprovalVote adds `confidence`).
+ */
+
+// Ballot types
+export { BaseBallot, BinaryBallot, isBinaryBallot } from './BaseBallot';
+
+// Rules and status
+export {
+  VotingRules,
+  DEFAULT_VOTING_RULES,
+  MAJORITY_VOTING_RULES,
+  validateVotingRules,
+} from './VotingRules';
+
+export {
+  VoteStatus,
+  VotingSummary,
+  VotingPatternAnalysis,
+} from './VoteStatus';
+
+// Interfaces
+export {
+  IVotingMechanism,
+  IVoteValidator,
+  VotingContext,
+} from './IVotingMechanism';
+
+// Calculator
+export { GenericVoteCalculator } from './VoteCalculator';

--- a/tests/unit/core/relationships/RelationshipGraph.test.ts
+++ b/tests/unit/core/relationships/RelationshipGraph.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Tests for RelationshipGraph
+ *
+ * Tests the generic graph operations for relationship collections.
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RelationshipGraph } from '../../../../src/core/relationships/RelationshipGraph';
+import { IRelationship, toRelationship, isRelationship } from '../../../../src/core/relationships/IRelationship';
+import type { ActionId } from '../../../../src/core/simulation/IAction';
+
+describe('RelationshipGraph', () => {
+  let graph: RelationshipGraph;
+
+  // Helper to create action IDs
+  const createActionId = (index: number): ActionId => `action-${index}`;
+
+  // Define test relationship types
+  type TestRelationType = 'rebuts' | 'supports' | 'builds_on';
+
+  // Helper to create relationships
+  const createRelationship = (
+    fromIndex: number,
+    toIndices: number[],
+    type: TestRelationType
+  ): IRelationship<TestRelationType> => ({
+    fromId: createActionId(fromIndex),
+    toIds: toIndices.map(createActionId),
+    type,
+  });
+
+  beforeEach(() => {
+    graph = new RelationshipGraph();
+  });
+
+  describe('detectCycles', () => {
+    it('should return ok for empty relationships', () => {
+      const result = graph.detectCycles([]);
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should return ok for acyclic graph', () => {
+      // A -> B -> C (linear chain)
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+        createRelationship(2, [3], 'rebuts'),
+      ];
+
+      const result = graph.detectCycles(relationships);
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should return ok for tree structure', () => {
+      //     A
+      //    / \
+      //   B   C
+      //  / \
+      // D   E
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2, 3], 'supports'),
+        createRelationship(2, [4, 5], 'supports'),
+      ];
+
+      const result = graph.detectCycles(relationships);
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should detect simple cycle', () => {
+      // A -> B -> A (cycle)
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+        createRelationship(2, [1], 'rebuts'),
+      ];
+
+      const result = graph.detectCycles(relationships);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain('Circular reference');
+      }
+    });
+
+    it('should detect longer cycle', () => {
+      // A -> B -> C -> A (cycle)
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+        createRelationship(2, [3], 'rebuts'),
+        createRelationship(3, [1], 'rebuts'),
+      ];
+
+      const result = graph.detectCycles(relationships);
+
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('should detect self-loop', () => {
+      // A -> A (self-loop)
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [1], 'supports'),
+      ];
+
+      const result = graph.detectCycles(relationships);
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('findTargeting', () => {
+    it('should return empty for no targeting relationships', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+      ];
+
+      const targeting = graph.findTargeting(createActionId(1), relationships);
+
+      expect(targeting).toHaveLength(0);
+    });
+
+    it('should find relationships targeting an action', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [3], 'rebuts'),
+        createRelationship(2, [3], 'supports'),
+        createRelationship(3, [4], 'builds_on'),
+      ];
+
+      const targeting = graph.findTargeting(createActionId(3), relationships);
+
+      expect(targeting).toHaveLength(2);
+      expect(targeting.map(r => r.fromId)).toContain(createActionId(1));
+      expect(targeting.map(r => r.fromId)).toContain(createActionId(2));
+    });
+
+    it('should handle multi-target relationships', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2, 3, 4], 'supports'),
+      ];
+
+      expect(graph.findTargeting(createActionId(2), relationships)).toHaveLength(1);
+      expect(graph.findTargeting(createActionId(3), relationships)).toHaveLength(1);
+      expect(graph.findTargeting(createActionId(4), relationships)).toHaveLength(1);
+      expect(graph.findTargeting(createActionId(5), relationships)).toHaveLength(0);
+    });
+  });
+
+  describe('findFrom', () => {
+    it('should return empty for no outgoing relationships', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+      ];
+
+      const from = graph.findFrom(createActionId(2), relationships);
+
+      expect(from).toHaveLength(0);
+    });
+
+    it('should find all relationships from an action', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+        createRelationship(1, [3], 'supports'),
+        createRelationship(2, [3], 'builds_on'),
+      ];
+
+      const from = graph.findFrom(createActionId(1), relationships);
+
+      expect(from).toHaveLength(2);
+      expect(from.map(r => r.type)).toContain('rebuts');
+      expect(from.map(r => r.type)).toContain('supports');
+    });
+  });
+
+  describe('findInvolving', () => {
+    it('should find all relationships involving an action', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),    // Action 2 is target
+        createRelationship(2, [3], 'supports'),  // Action 2 is source
+        createRelationship(3, [4], 'builds_on'), // Action 2 not involved
+      ];
+
+      const involving = graph.findInvolving(createActionId(2), relationships);
+
+      expect(involving).toHaveLength(2);
+    });
+
+    it('should include multi-target relationships', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2, 3, 4], 'supports'),
+      ];
+
+      const involving = graph.findInvolving(createActionId(3), relationships);
+
+      expect(involving).toHaveLength(1);
+    });
+  });
+
+  describe('findByType', () => {
+    it('should filter by relationship type', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+        createRelationship(2, [3], 'supports'),
+        createRelationship(3, [4], 'rebuts'),
+        createRelationship(4, [5], 'builds_on'),
+      ];
+
+      const rebuttals = graph.findByType('rebuts', relationships);
+      const supports = graph.findByType('supports', relationships);
+      const builds = graph.findByType('builds_on', relationships);
+
+      expect(rebuttals).toHaveLength(2);
+      expect(supports).toHaveLength(1);
+      expect(builds).toHaveLength(1);
+    });
+  });
+
+  describe('buildChain', () => {
+    it('should build empty chain for isolated node', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(2, [3], 'rebuts'),
+      ];
+
+      const chain = graph.buildChain(createActionId(1), relationships);
+
+      expect(chain.rootId).toBe(createActionId(1));
+      expect(chain.relationships).toHaveLength(0);
+      expect(chain.depth).toBe(0);
+    });
+
+    it('should build linear chain', () => {
+      // 1 -> 2 -> 3
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+        createRelationship(2, [3], 'rebuts'),
+      ];
+
+      const chain = graph.buildChain(createActionId(1), relationships);
+
+      expect(chain.rootId).toBe(createActionId(1));
+      expect(chain.relationships).toHaveLength(2);
+      expect(chain.depth).toBe(2);
+    });
+
+    it('should build branching chain', () => {
+      //   1
+      //  / \
+      // 2   3
+      //     |
+      //     4
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2, 3], 'supports'),
+        createRelationship(3, [4], 'builds_on'),
+      ];
+
+      const chain = graph.buildChain(createActionId(1), relationships);
+
+      expect(chain.relationships).toHaveLength(2);
+    });
+  });
+
+  describe('calculateDepth', () => {
+    it('should return 0 for empty relationships', () => {
+      const depth = graph.calculateDepth([]);
+
+      expect(depth).toBe(0);
+    });
+
+    it('should calculate linear chain depth', () => {
+      // 1 -> 2 -> 3 -> 4 (depth 3)
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+        createRelationship(2, [3], 'rebuts'),
+        createRelationship(3, [4], 'rebuts'),
+      ];
+
+      const depth = graph.calculateDepth(relationships);
+
+      expect(depth).toBe(3);
+    });
+
+    it('should find max depth in branching graph', () => {
+      //   1        depth 0
+      //  / \
+      // 2   3      depth 1
+      //     |
+      //     4      depth 2
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2, 3], 'supports'),
+        createRelationship(3, [4], 'builds_on'),
+      ];
+
+      const depth = graph.calculateDepth(relationships);
+
+      expect(depth).toBe(2);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return stats for empty graph', () => {
+      const stats = graph.getStats([]);
+
+      expect(stats.relationshipCount).toBe(0);
+      expect(stats.actionCount).toBe(0);
+      expect(stats.maxDepth).toBe(0);
+      expect(stats.rootCount).toBe(0);
+      expect(stats.leafCount).toBe(0);
+    });
+
+    it('should calculate stats for simple graph', () => {
+      // 1 -> 2 -> 3
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+        createRelationship(2, [3], 'rebuts'),
+      ];
+
+      const stats = graph.getStats(relationships);
+
+      expect(stats.relationshipCount).toBe(2);
+      expect(stats.actionCount).toBe(3);
+      expect(stats.maxDepth).toBe(2);
+      expect(stats.rootCount).toBe(1); // 1 is root
+      expect(stats.leafCount).toBe(1); // 3 is leaf
+    });
+
+    it('should handle multiple roots and leaves', () => {
+      // 1 -> 3
+      // 2 -> 3
+      // 3 -> 4
+      // 3 -> 5
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [3], 'supports'),
+        createRelationship(2, [3], 'supports'),
+        createRelationship(3, [4], 'builds_on'),
+        createRelationship(3, [5], 'builds_on'),
+      ];
+
+      const stats = graph.getStats(relationships);
+
+      expect(stats.rootCount).toBe(2); // 1, 2 are roots
+      expect(stats.leafCount).toBe(2); // 4, 5 are leaves
+    });
+  });
+
+  describe('findRoots', () => {
+    it('should find root nodes', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [3], 'supports'),
+        createRelationship(2, [3], 'supports'),
+        createRelationship(3, [4], 'builds_on'),
+      ];
+
+      const roots = graph.findRoots(relationships);
+
+      expect(roots).toHaveLength(2);
+      expect(roots).toContain(createActionId(1));
+      expect(roots).toContain(createActionId(2));
+    });
+  });
+
+  describe('findLeaves', () => {
+    it('should find leaf nodes', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'supports'),
+        createRelationship(2, [3], 'builds_on'),
+        createRelationship(2, [4], 'builds_on'),
+      ];
+
+      const leaves = graph.findLeaves(relationships);
+
+      expect(leaves).toHaveLength(2);
+      expect(leaves).toContain(createActionId(3));
+      expect(leaves).toContain(createActionId(4));
+    });
+  });
+});
+
+describe('IRelationship utilities', () => {
+  describe('toRelationship', () => {
+    it('should convert single-target to standard format', () => {
+      const single = {
+        fromId: 'action-1',
+        toId: 'action-2',
+        type: 'rebuts' as const,
+        strength: 0.8,
+      };
+
+      const result = toRelationship(single);
+
+      expect(result.fromId).toBe('action-1');
+      expect(result.toIds).toEqual(['action-2']);
+      expect(result.type).toBe('rebuts');
+      expect(result.strength).toBe(0.8);
+    });
+  });
+
+  describe('isRelationship', () => {
+    it('should return true for valid relationship', () => {
+      const rel: IRelationship = {
+        fromId: 'action-1',
+        toIds: ['action-2'],
+        type: 'rebuts',
+      };
+
+      expect(isRelationship(rel)).toBe(true);
+    });
+
+    it('should return false for null', () => {
+      expect(isRelationship(null)).toBe(false);
+    });
+
+    it('should return false for missing fromId', () => {
+      expect(isRelationship({ toIds: ['a'], type: 'x' })).toBe(false);
+    });
+
+    it('should return false for missing toIds', () => {
+      expect(isRelationship({ fromId: 'a', type: 'x' })).toBe(false);
+    });
+
+    it('should return false for non-array toIds', () => {
+      expect(isRelationship({ fromId: 'a', toIds: 'b', type: 'x' })).toBe(false);
+    });
+
+    it('should return false for missing type', () => {
+      expect(isRelationship({ fromId: 'a', toIds: ['b'] })).toBe(false);
+    });
+  });
+});

--- a/tests/unit/core/relationships/RelationshipGraph.test.ts
+++ b/tests/unit/core/relationships/RelationshipGraph.test.ts
@@ -6,7 +6,7 @@
 
 import 'reflect-metadata';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { RelationshipGraph } from '../../../../src/core/relationships/RelationshipGraph';
+import { RelationshipGraph, MAX_GRAPH_DEPTH } from '../../../../src/core/relationships/RelationshipGraph';
 import { IRelationship, toRelationship, isRelationship } from '../../../../src/core/relationships/IRelationship';
 import type { ActionId } from '../../../../src/core/simulation/IAction';
 
@@ -373,6 +373,135 @@ describe('RelationshipGraph', () => {
       expect(leaves).toContain(createActionId(4));
     });
   });
+
+  describe('buildIndex', () => {
+    it('should build empty index for empty relationships', () => {
+      const index = graph.buildIndex([]);
+
+      expect(index.outgoing.size).toBe(0);
+      expect(index.incoming.size).toBe(0);
+      expect(index.allNodes.size).toBe(0);
+    });
+
+    it('should track all nodes in the graph', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2, 3], 'supports'),
+        createRelationship(2, [4], 'rebuts'),
+      ];
+
+      const index = graph.buildIndex(relationships);
+
+      expect(index.allNodes.size).toBe(4);
+      expect(index.allNodes.has(createActionId(1))).toBe(true);
+      expect(index.allNodes.has(createActionId(2))).toBe(true);
+      expect(index.allNodes.has(createActionId(3))).toBe(true);
+      expect(index.allNodes.has(createActionId(4))).toBe(true);
+    });
+
+    it('should build correct outgoing index', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'supports'),
+        createRelationship(1, [3], 'rebuts'),
+        createRelationship(2, [4], 'builds_on'),
+      ];
+
+      const index = graph.buildIndex(relationships);
+
+      // Node 1 has two outgoing relationships
+      expect(index.outgoing.get(createActionId(1))).toHaveLength(2);
+      // Node 2 has one outgoing relationship
+      expect(index.outgoing.get(createActionId(2))).toHaveLength(1);
+      // Node 3 has no outgoing relationships
+      expect(index.outgoing.has(createActionId(3))).toBe(false);
+    });
+
+    it('should build correct incoming index', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [3], 'supports'),
+        createRelationship(2, [3], 'rebuts'),
+      ];
+
+      const index = graph.buildIndex(relationships);
+
+      // Node 3 has two incoming relationships
+      expect(index.incoming.get(createActionId(3))).toHaveLength(2);
+      // Node 1 has no incoming relationships
+      expect(index.incoming.has(createActionId(1))).toBe(false);
+    });
+  });
+
+  describe('depth limiting', () => {
+    it('should detect cycle within depth limit', () => {
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'rebuts'),
+        createRelationship(2, [1], 'rebuts'),
+      ];
+
+      const result = graph.detectCycles(relationships, 10);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain('Circular reference');
+      }
+    });
+
+    it('should return error when depth limit exceeded', () => {
+      // Create a very deep linear chain: 1 -> 2 -> 3 -> ... -> 15
+      const relationships: IRelationship<TestRelationType>[] = [];
+      for (let i = 1; i <= 14; i++) {
+        relationships.push(createRelationship(i, [i + 1], 'supports'));
+      }
+
+      // With depth limit of 10, traversal should fail
+      const result = graph.detectCycles(relationships, 10);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain('exceeded maximum depth');
+      }
+    });
+
+    it('should allow deep graphs within default depth limit', () => {
+      // Create a chain within MAX_GRAPH_DEPTH
+      const relationships: IRelationship<TestRelationType>[] = [];
+      for (let i = 1; i <= 100; i++) {
+        relationships.push(createRelationship(i, [i + 1], 'supports'));
+      }
+
+      const result = graph.detectCycles(relationships);
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should respect custom depth limit in buildChain', () => {
+      // Create chain: 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7
+      const relationships: IRelationship<TestRelationType>[] = [
+        createRelationship(1, [2], 'supports'),
+        createRelationship(2, [3], 'supports'),
+        createRelationship(3, [4], 'supports'),
+        createRelationship(4, [5], 'supports'),
+        createRelationship(5, [6], 'supports'),
+        createRelationship(6, [7], 'supports'),
+      ];
+
+      // Full chain should have all 6 relationships
+      const fullChain = graph.buildChain(createActionId(1), relationships);
+      expect(fullChain.relationships).toHaveLength(6);
+
+      // With depth limit of 2, traversal starts at depth 0 and stops when > 2
+      // So we traverse: depth 0 (node 1), depth 1 (node 2), depth 2 (node 3)
+      // and stop before depth 3, meaning 2 relationships collected
+      const limitedChain = graph.buildChain(createActionId(1), relationships, 2);
+
+      // With limit 2, should have fewer relationships than full chain
+      expect(limitedChain.relationships.length).toBeLessThan(fullChain.relationships.length);
+    });
+
+    it('should use MAX_GRAPH_DEPTH as default limit', () => {
+      // Verify the constant is exported and reasonable
+      expect(MAX_GRAPH_DEPTH).toBe(1000);
+    });
+  });
 });
 
 describe('IRelationship utilities', () => {
@@ -405,6 +534,17 @@ describe('IRelationship utilities', () => {
       expect(isRelationship(rel)).toBe(true);
     });
 
+    it('should return true for relationship with valid strength', () => {
+      const rel = {
+        fromId: 'action-1',
+        toIds: ['action-2'],
+        type: 'rebuts',
+        strength: 0.5,
+      };
+
+      expect(isRelationship(rel)).toBe(true);
+    });
+
     it('should return false for null', () => {
       expect(isRelationship(null)).toBe(false);
     });
@@ -413,16 +553,49 @@ describe('IRelationship utilities', () => {
       expect(isRelationship({ toIds: ['a'], type: 'x' })).toBe(false);
     });
 
+    it('should return false for empty fromId', () => {
+      expect(isRelationship({ fromId: '', toIds: ['a'], type: 'x' })).toBe(false);
+    });
+
     it('should return false for missing toIds', () => {
       expect(isRelationship({ fromId: 'a', type: 'x' })).toBe(false);
+    });
+
+    it('should return false for empty toIds array', () => {
+      expect(isRelationship({ fromId: 'a', toIds: [], type: 'x' })).toBe(false);
     });
 
     it('should return false for non-array toIds', () => {
       expect(isRelationship({ fromId: 'a', toIds: 'b', type: 'x' })).toBe(false);
     });
 
+    it('should return false for toIds containing non-strings', () => {
+      expect(isRelationship({ fromId: 'a', toIds: [123], type: 'x' })).toBe(false);
+    });
+
+    it('should return false for toIds containing empty strings', () => {
+      expect(isRelationship({ fromId: 'a', toIds: ['b', ''], type: 'x' })).toBe(false);
+    });
+
     it('should return false for missing type', () => {
       expect(isRelationship({ fromId: 'a', toIds: ['b'] })).toBe(false);
+    });
+
+    it('should return false for empty type', () => {
+      expect(isRelationship({ fromId: 'a', toIds: ['b'], type: '' })).toBe(false);
+    });
+
+    it('should return false for strength below 0', () => {
+      expect(isRelationship({ fromId: 'a', toIds: ['b'], type: 'x', strength: -0.1 })).toBe(false);
+    });
+
+    it('should return false for strength above 1', () => {
+      expect(isRelationship({ fromId: 'a', toIds: ['b'], type: 'x', strength: 1.1 })).toBe(false);
+    });
+
+    it('should return true for strength at boundaries (0 and 1)', () => {
+      expect(isRelationship({ fromId: 'a', toIds: ['b'], type: 'x', strength: 0 })).toBe(true);
+      expect(isRelationship({ fromId: 'a', toIds: ['b'], type: 'x', strength: 1 })).toBe(true);
     });
   });
 });

--- a/tests/unit/core/simulation/SimulationTypeRegistry.test.ts
+++ b/tests/unit/core/simulation/SimulationTypeRegistry.test.ts
@@ -219,3 +219,93 @@ describe('SimulationType', () => {
     });
   });
 });
+
+// Import isAction for testing
+import { isAction } from '../../../../src/core/simulation/IAction';
+
+describe('isAction', () => {
+  const validAction = {
+    id: 'action-123',
+    simulationId: 'sim-456',
+    agentId: 'agent-789',
+    timestamp: '2025-01-01T10:00:00.000Z',
+    actionType: 'argument',
+    content: 'This is a test argument',
+  };
+
+  it('should return true for valid action', () => {
+    expect(isAction(validAction)).toBe(true);
+  });
+
+  it('should return true for action with empty content', () => {
+    expect(isAction({ ...validAction, content: '' })).toBe(true);
+  });
+
+  it('should return false for null', () => {
+    expect(isAction(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isAction(undefined)).toBe(false);
+  });
+
+  it('should return false for non-object', () => {
+    expect(isAction('string')).toBe(false);
+    expect(isAction(123)).toBe(false);
+  });
+
+  it('should return false for empty id', () => {
+    expect(isAction({ ...validAction, id: '' })).toBe(false);
+  });
+
+  it('should return false for empty simulationId', () => {
+    expect(isAction({ ...validAction, simulationId: '' })).toBe(false);
+  });
+
+  it('should return false for empty agentId', () => {
+    expect(isAction({ ...validAction, agentId: '' })).toBe(false);
+  });
+
+  it('should return false for empty actionType', () => {
+    expect(isAction({ ...validAction, actionType: '' })).toBe(false);
+  });
+
+  it('should return false for empty timestamp', () => {
+    expect(isAction({ ...validAction, timestamp: '' })).toBe(false);
+  });
+
+  it('should return false for invalid timestamp format', () => {
+    expect(isAction({ ...validAction, timestamp: 'not-a-date' })).toBe(false);
+  });
+
+  it('should return true for various valid timestamp formats', () => {
+    expect(isAction({ ...validAction, timestamp: '2025-01-01' })).toBe(true);
+    expect(isAction({ ...validAction, timestamp: '2025-01-01T10:00:00Z' })).toBe(true);
+    expect(isAction({ ...validAction, timestamp: 'January 1, 2025' })).toBe(true);
+  });
+
+  it('should return false for missing required fields', () => {
+    const { id, ...withoutId } = validAction;
+    expect(isAction(withoutId)).toBe(false);
+
+    const { simulationId, ...withoutSimId } = validAction;
+    expect(isAction(withoutSimId)).toBe(false);
+
+    const { agentId, ...withoutAgentId } = validAction;
+    expect(isAction(withoutAgentId)).toBe(false);
+
+    const { timestamp, ...withoutTimestamp } = validAction;
+    expect(isAction(withoutTimestamp)).toBe(false);
+
+    const { actionType, ...withoutActionType } = validAction;
+    expect(isAction(withoutActionType)).toBe(false);
+
+    const { content, ...withoutContent } = validAction;
+    expect(isAction(withoutContent)).toBe(false);
+  });
+
+  it('should return false for non-string content', () => {
+    expect(isAction({ ...validAction, content: 123 })).toBe(false);
+    expect(isAction({ ...validAction, content: null })).toBe(false);
+  });
+});

--- a/tests/unit/core/simulation/SimulationTypeRegistry.test.ts
+++ b/tests/unit/core/simulation/SimulationTypeRegistry.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for SimulationTypeRegistry
+ *
+ * Tests the static registry pattern for simulation types.
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  SimulationTypeRegistry,
+} from '../../../../src/core/simulation/SimulationTypeRegistry';
+import type { SimulationTypeInfo } from '../../../../src/core/simulation/ISimulationConfig';
+import { SimulationTypeFactory, SimulationType } from '../../../../src/core/simulation/SimulationType';
+
+describe('SimulationTypeRegistry', () => {
+  // Create a mock registration for testing
+  const createMockRegistration = (
+    type: SimulationType,
+    name: string = 'Test Simulation'
+  ): SimulationTypeInfo => ({
+    type,
+    name,
+    description: `A ${name.toLowerCase()} simulation type`,
+    actionTypes: ['action1', 'action2'],
+  });
+
+  beforeEach(() => {
+    // Clear registry before each test
+    SimulationTypeRegistry.clear();
+  });
+
+  afterEach(() => {
+    // Clean up after tests
+    SimulationTypeRegistry.clear();
+  });
+
+  describe('register', () => {
+    it('should register a new simulation type', () => {
+      const registration = createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate');
+
+      // register is void (throws on error)
+      SimulationTypeRegistry.register(registration);
+
+      expect(SimulationTypeRegistry.has(SimulationTypeFactory.DEBATE)).toBe(true);
+    });
+
+    it('should throw error when registering duplicate type', () => {
+      const registration = createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate');
+
+      SimulationTypeRegistry.register(registration);
+
+      expect(() => SimulationTypeRegistry.register(registration)).toThrow('already registered');
+    });
+
+    it('should register multiple different types', () => {
+      const debateReg = createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate');
+      const decisionReg = createMockRegistration(SimulationTypeFactory.DECISION, 'Decision');
+      const brainstormReg = createMockRegistration(SimulationTypeFactory.BRAINSTORM, 'Brainstorm');
+
+      SimulationTypeRegistry.register(debateReg);
+      SimulationTypeRegistry.register(decisionReg);
+      SimulationTypeRegistry.register(brainstormReg);
+
+      expect(SimulationTypeRegistry.has(SimulationTypeFactory.DEBATE)).toBe(true);
+      expect(SimulationTypeRegistry.has(SimulationTypeFactory.DECISION)).toBe(true);
+      expect(SimulationTypeRegistry.has(SimulationTypeFactory.BRAINSTORM)).toBe(true);
+    });
+  });
+
+  describe('get', () => {
+    it('should return registration for registered type', () => {
+      const registration = createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate');
+      SimulationTypeRegistry.register(registration);
+
+      const result = SimulationTypeRegistry.get(SimulationTypeFactory.DEBATE);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.type).toBe(SimulationTypeFactory.DEBATE);
+        expect(result.value.name).toBe('Debate');
+      }
+    });
+
+    it('should return error for unregistered type', () => {
+      const result = SimulationTypeRegistry.get(SimulationTypeFactory.DEBATE);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain('Unknown simulation type');
+      }
+    });
+  });
+
+  describe('has', () => {
+    it('should return true for registered type', () => {
+      const registration = createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate');
+      SimulationTypeRegistry.register(registration);
+
+      expect(SimulationTypeRegistry.has(SimulationTypeFactory.DEBATE)).toBe(true);
+    });
+
+    it('should return false for unregistered type', () => {
+      expect(SimulationTypeRegistry.has(SimulationTypeFactory.DEBATE)).toBe(false);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return empty array when no types registered', () => {
+      const all = SimulationTypeRegistry.getAll();
+
+      expect(all).toHaveLength(0);
+    });
+
+    it('should return all registered types', () => {
+      SimulationTypeRegistry.register(createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate'));
+      SimulationTypeRegistry.register(createMockRegistration(SimulationTypeFactory.DECISION, 'Decision'));
+
+      const all = SimulationTypeRegistry.getAll();
+
+      expect(all).toHaveLength(2);
+      expect(all.map(r => r.type)).toContain(SimulationTypeFactory.DEBATE);
+      expect(all.map(r => r.type)).toContain(SimulationTypeFactory.DECISION);
+    });
+
+    it('should return defensive copy (not allow mutation)', () => {
+      SimulationTypeRegistry.register(createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate'));
+
+      const all1 = SimulationTypeRegistry.getAll();
+      // Try to mutate the array - but since it's readonly, this won't compile
+      // We can still test that the array contents are preserved
+      const originalLength = all1.length;
+
+      const all2 = SimulationTypeRegistry.getAll();
+      expect(all2).toHaveLength(originalLength);
+    });
+  });
+
+  describe('getTypeNames', () => {
+    it('should return empty array when no types registered', () => {
+      const names = SimulationTypeRegistry.getTypeNames();
+
+      expect(names).toHaveLength(0);
+    });
+
+    it('should return all registered type names', () => {
+      SimulationTypeRegistry.register(createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate'));
+      SimulationTypeRegistry.register(createMockRegistration(SimulationTypeFactory.DECISION, 'Decision'));
+
+      const names = SimulationTypeRegistry.getTypeNames();
+
+      expect(names).toHaveLength(2);
+      expect(names).toContain('debate');
+      expect(names).toContain('decision');
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all registered types', () => {
+      SimulationTypeRegistry.register(createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate'));
+      SimulationTypeRegistry.register(createMockRegistration(SimulationTypeFactory.DECISION, 'Decision'));
+
+      expect(SimulationTypeRegistry.getAll()).toHaveLength(2);
+
+      SimulationTypeRegistry.clear();
+
+      expect(SimulationTypeRegistry.getAll()).toHaveLength(0);
+      expect(SimulationTypeRegistry.has(SimulationTypeFactory.DEBATE)).toBe(false);
+      expect(SimulationTypeRegistry.has(SimulationTypeFactory.DECISION)).toBe(false);
+    });
+  });
+
+  describe('count', () => {
+    it('should return 0 when no types registered', () => {
+      expect(SimulationTypeRegistry.count).toBe(0);
+    });
+
+    it('should return correct count after registrations', () => {
+      SimulationTypeRegistry.register(createMockRegistration(SimulationTypeFactory.DEBATE, 'Debate'));
+      expect(SimulationTypeRegistry.count).toBe(1);
+
+      SimulationTypeRegistry.register(createMockRegistration(SimulationTypeFactory.DECISION, 'Decision'));
+      expect(SimulationTypeRegistry.count).toBe(2);
+    });
+  });
+});
+
+describe('SimulationType', () => {
+  describe('SimulationTypeFactory.create', () => {
+    it('should create valid simulation types', () => {
+      const debate = SimulationTypeFactory.create('debate');
+      const decision = SimulationTypeFactory.create('decision');
+      const brainstorm = SimulationTypeFactory.create('brainstorm');
+
+      expect(debate).toBe('debate');
+      expect(decision).toBe('decision');
+      expect(brainstorm).toBe('brainstorm');
+    });
+  });
+
+  describe('SimulationTypeFactory.isValid', () => {
+    it('should return true for valid type names', () => {
+      expect(SimulationTypeFactory.isValid('debate')).toBe(true);
+      expect(SimulationTypeFactory.isValid('decision')).toBe(true);
+      expect(SimulationTypeFactory.isValid('brainstorm')).toBe(true);
+    });
+
+    it('should return false for invalid type names', () => {
+      expect(SimulationTypeFactory.isValid('invalid')).toBe(false);
+      expect(SimulationTypeFactory.isValid('')).toBe(false);
+      expect(SimulationTypeFactory.isValid('DEBATE')).toBe(false); // Case sensitive
+    });
+  });
+
+  describe('SimulationTypeFactory constants', () => {
+    it('should provide type-safe constants', () => {
+      expect(SimulationTypeFactory.DEBATE).toBe('debate');
+      expect(SimulationTypeFactory.DECISION).toBe('decision');
+      expect(SimulationTypeFactory.BRAINSTORM).toBe('brainstorm');
+    });
+  });
+});

--- a/tests/unit/core/voting/GenericVoteCalculator.test.ts
+++ b/tests/unit/core/voting/GenericVoteCalculator.test.ts
@@ -134,6 +134,7 @@ describe('GenericVoteCalculator', () => {
       const customRules: VotingRules = {
         requireUnanimity: false,
         minimumParticipation: 0.8,
+        allowAbstention: false,
       };
 
       const status = calculator.calculateStatus(ballots, participants, customRules);
@@ -336,5 +337,162 @@ describe('GenericVoteCalculator', () => {
       expect(pattern.quickestVote).toBe(5000);
       expect(pattern.slowestVote).toBe(10000);
     });
+  });
+});
+
+// Import validateVotingRules for testing
+import { validateVotingRules } from '../../../../src/core/voting/VotingRules';
+
+describe('validateVotingRules', () => {
+  it('should return null for valid default rules', () => {
+    const error = validateVotingRules(DEFAULT_VOTING_RULES);
+    expect(error).toBeNull();
+  });
+
+  it('should return null for valid majority rules', () => {
+    const error = validateVotingRules(MAJORITY_VOTING_RULES);
+    expect(error).toBeNull();
+  });
+
+  it('should return null for minimumParticipation at 0', () => {
+    const rules: VotingRules = {
+      requireUnanimity: false,
+      minimumParticipation: 0,
+      allowAbstention: false,
+    };
+    expect(validateVotingRules(rules)).toBeNull();
+  });
+
+  it('should return null for minimumParticipation at 1', () => {
+    const rules: VotingRules = {
+      requireUnanimity: true,
+      minimumParticipation: 1,
+      allowAbstention: false,
+    };
+    expect(validateVotingRules(rules)).toBeNull();
+  });
+
+  it('should return null for minimumParticipation at 0.5', () => {
+    const rules: VotingRules = {
+      requireUnanimity: false,
+      minimumParticipation: 0.5,
+      allowAbstention: true,
+    };
+    expect(validateVotingRules(rules)).toBeNull();
+  });
+
+  it('should return error for minimumParticipation below 0', () => {
+    const rules: VotingRules = {
+      requireUnanimity: false,
+      minimumParticipation: -0.1,
+      allowAbstention: false,
+    };
+    const error = validateVotingRules(rules);
+    expect(error).not.toBeNull();
+    expect(error).toContain('minimumParticipation');
+  });
+
+  it('should return error for minimumParticipation above 1', () => {
+    const rules: VotingRules = {
+      requireUnanimity: false,
+      minimumParticipation: 1.1,
+      allowAbstention: false,
+    };
+    const error = validateVotingRules(rules);
+    expect(error).not.toBeNull();
+    expect(error).toContain('minimumParticipation');
+  });
+
+  it('should return error for minimumParticipation significantly above 1', () => {
+    const rules: VotingRules = {
+      requireUnanimity: false,
+      minimumParticipation: 2.0,
+      allowAbstention: false,
+    };
+    const error = validateVotingRules(rules);
+    expect(error).not.toBeNull();
+  });
+
+  it('should return error for negative minimumParticipation', () => {
+    const rules: VotingRules = {
+      requireUnanimity: false,
+      minimumParticipation: -1,
+      allowAbstention: false,
+    };
+    const error = validateVotingRules(rules);
+    expect(error).not.toBeNull();
+  });
+});
+
+// Import isBinaryBallot for testing
+import { isBinaryBallot, BaseBallot } from '../../../../src/core/voting/BaseBallot';
+
+describe('isBinaryBallot', () => {
+  const createBaseBallot = (): BaseBallot => ({
+    agentId: 'agent-1' as AgentId,
+    timestamp: '2025-01-01T10:00:00Z' as unknown as Timestamp,
+  });
+
+  it('should return true for ballot with boolean vote=true', () => {
+    const ballot = {
+      ...createBaseBallot(),
+      vote: true,
+    };
+    expect(isBinaryBallot(ballot)).toBe(true);
+  });
+
+  it('should return true for ballot with boolean vote=false', () => {
+    const ballot = {
+      ...createBaseBallot(),
+      vote: false,
+    };
+    expect(isBinaryBallot(ballot)).toBe(true);
+  });
+
+  it('should return false for ballot without vote property', () => {
+    const ballot = createBaseBallot();
+    expect(isBinaryBallot(ballot)).toBe(false);
+  });
+
+  it('should return false for ballot with non-boolean vote', () => {
+    const ballot = {
+      ...createBaseBallot(),
+      vote: 'yes', // string, not boolean
+    };
+    expect(isBinaryBallot(ballot as unknown as BaseBallot)).toBe(false);
+  });
+
+  it('should return false for ballot with numeric vote', () => {
+    const ballot = {
+      ...createBaseBallot(),
+      vote: 1, // number, not boolean
+    };
+    expect(isBinaryBallot(ballot as unknown as BaseBallot)).toBe(false);
+  });
+
+  it('should return false for ballot with null vote', () => {
+    const ballot = {
+      ...createBaseBallot(),
+      vote: null,
+    };
+    expect(isBinaryBallot(ballot as unknown as BaseBallot)).toBe(false);
+  });
+
+  it('should return false for ballot with undefined vote', () => {
+    const ballot = {
+      ...createBaseBallot(),
+      vote: undefined,
+    };
+    expect(isBinaryBallot(ballot as unknown as BaseBallot)).toBe(false);
+  });
+
+  it('should return true for ballot with extra properties', () => {
+    const ballot = {
+      ...createBaseBallot(),
+      vote: true,
+      reason: 'I agree with the proposal',
+      confidence: 0.9,
+    };
+    expect(isBinaryBallot(ballot)).toBe(true);
   });
 });

--- a/tests/unit/core/voting/GenericVoteCalculator.test.ts
+++ b/tests/unit/core/voting/GenericVoteCalculator.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for GenericVoteCalculator
+ *
+ * Tests the generic vote calculation functions that work with any ballot type.
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GenericVoteCalculator } from '../../../../src/core/voting/VoteCalculator';
+import { BinaryBallot } from '../../../../src/core/voting/BaseBallot';
+import { VotingRules, DEFAULT_VOTING_RULES, MAJORITY_VOTING_RULES } from '../../../../src/core/voting/VotingRules';
+import type { AgentId } from '../../../../src/core/value-objects/AgentId';
+import type { Timestamp } from '../../../../src/core/value-objects/Timestamp';
+
+describe('GenericVoteCalculator', () => {
+  let calculator: GenericVoteCalculator;
+
+  // Helper to create test agent IDs
+  const createAgentId = (index: number): AgentId => `agent-${index}` as AgentId;
+
+  // Helper to create test timestamps
+  const createTimestamp = (date: string): Timestamp => date as unknown as Timestamp;
+
+  // Helper to create binary ballots
+  const createBallot = (
+    agentId: AgentId,
+    vote: boolean,
+    timestamp: string = '2025-01-01T10:00:00Z'
+  ): BinaryBallot => ({
+    agentId,
+    vote,
+    timestamp: createTimestamp(timestamp),
+  });
+
+  beforeEach(() => {
+    calculator = new GenericVoteCalculator();
+  });
+
+  describe('calculateStatus', () => {
+    it('should return zero counts with no ballots', () => {
+      const ballots: BinaryBallot[] = [];
+      const participants = [createAgentId(1), createAgentId(2)];
+
+      const status = calculator.calculateStatus(ballots, participants);
+
+      expect(status.total).toBe(0);
+      expect(status.required).toBe(2);
+      expect(status.yesVotes).toBe(0);
+      expect(status.noVotes).toBe(0);
+      expect(status.hasConsensus).toBe(false);
+      expect(status.participationRate).toBe(0);
+    });
+
+    it('should calculate unanimous yes consensus', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const ballots = [
+        createBallot(agent1, true),
+        createBallot(agent2, true),
+      ];
+      const participants = [agent1, agent2];
+
+      const status = calculator.calculateStatus(ballots, participants, DEFAULT_VOTING_RULES);
+
+      expect(status.total).toBe(2);
+      expect(status.required).toBe(2);
+      expect(status.yesVotes).toBe(2);
+      expect(status.noVotes).toBe(0);
+      expect(status.hasConsensus).toBe(true);
+      expect(status.participationRate).toBe(1.0);
+    });
+
+    it('should not have consensus with mixed votes (unanimity required)', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const ballots = [
+        createBallot(agent1, true),
+        createBallot(agent2, false),
+      ];
+      const participants = [agent1, agent2];
+
+      const status = calculator.calculateStatus(ballots, participants, DEFAULT_VOTING_RULES);
+
+      expect(status.yesVotes).toBe(1);
+      expect(status.noVotes).toBe(1);
+      expect(status.hasConsensus).toBe(false);
+    });
+
+    it('should handle majority voting rules', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const agent3 = createAgentId(3);
+      const ballots = [
+        createBallot(agent1, true),
+        createBallot(agent2, true),
+        createBallot(agent3, false),
+      ];
+      const participants = [agent1, agent2, agent3];
+
+      // With majority rules, 2/3 yes should be consensus
+      const status = calculator.calculateStatus(ballots, participants, MAJORITY_VOTING_RULES);
+
+      expect(status.yesVotes).toBe(2);
+      expect(status.noVotes).toBe(1);
+      expect(status.hasConsensus).toBe(true);
+    });
+
+    it('should calculate partial participation rate', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const agent3 = createAgentId(3);
+      const ballots = [createBallot(agent1, true)];
+      const participants = [agent1, agent2, agent3];
+
+      const status = calculator.calculateStatus(ballots, participants);
+
+      expect(status.total).toBe(1);
+      expect(status.required).toBe(3);
+      expect(status.participationRate).toBeCloseTo(0.333, 2);
+      expect(status.hasConsensus).toBe(false);
+    });
+
+    it('should handle custom minimum participation', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const agent3 = createAgentId(3);
+      const ballots = [
+        createBallot(agent1, true),
+        createBallot(agent2, true),
+      ];
+      const participants = [agent1, agent2, agent3];
+
+      // Custom rules: require 80% participation
+      const customRules: VotingRules = {
+        requireUnanimity: false,
+        minimumParticipation: 0.8,
+      };
+
+      const status = calculator.calculateStatus(ballots, participants, customRules);
+
+      // 2/3 = 66% < 80% required
+      expect(status.participationRate).toBeCloseTo(0.666, 2);
+      expect(status.thresholdMet).toBe(false);
+      expect(status.hasConsensus).toBe(false);
+    });
+  });
+
+  describe('getSummary', () => {
+    it('should return correct summary structure', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const agent3 = createAgentId(3);
+      const ballots = [
+        createBallot(agent1, true),
+        createBallot(agent2, false),
+      ];
+      const participants = [agent1, agent2, agent3];
+
+      const summary = calculator.getSummary(ballots, participants);
+
+      expect(summary.participants).toBe(3);
+      expect(summary.voted).toBe(2);
+      expect(summary.pending).toBe(1);
+      expect(summary.yesVotes).toBe(1);
+      expect(summary.noVotes).toBe(1);
+      expect(summary.consensusReached).toBe(false);
+    });
+
+    it('should detect consensus reached', () => {
+      const agent1 = createAgentId(1);
+      const ballots = [createBallot(agent1, true)];
+      const participants = [agent1];
+
+      const summary = calculator.getSummary(ballots, participants);
+
+      expect(summary.consensusReached).toBe(true);
+    });
+  });
+
+  describe('getPendingVoters', () => {
+    it('should return all participants when no votes', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const ballots: BinaryBallot[] = [];
+      const participants = [agent1, agent2];
+
+      const pending = calculator.getPendingVoters(ballots, participants);
+
+      expect(pending).toHaveLength(2);
+      expect(pending).toContain(agent1);
+      expect(pending).toContain(agent2);
+    });
+
+    it('should exclude agents who voted', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const agent3 = createAgentId(3);
+      const ballots = [createBallot(agent1, true)];
+      const participants = [agent1, agent2, agent3];
+
+      const pending = calculator.getPendingVoters(ballots, participants);
+
+      expect(pending).toHaveLength(2);
+      expect(pending).not.toContain(agent1);
+      expect(pending).toContain(agent2);
+      expect(pending).toContain(agent3);
+    });
+
+    it('should return empty array when all voted', () => {
+      const agent1 = createAgentId(1);
+      const ballots = [createBallot(agent1, true)];
+      const participants = [agent1];
+
+      const pending = calculator.getPendingVoters(ballots, participants);
+
+      expect(pending).toHaveLength(0);
+    });
+  });
+
+  describe('calculateVotesNeeded', () => {
+    it('should return 0 when consensus reached', () => {
+      const agent1 = createAgentId(1);
+      const ballots = [createBallot(agent1, true)];
+      const participants = [agent1];
+
+      const needed = calculator.calculateVotesNeeded(ballots, participants);
+
+      expect(needed).toBe(0);
+    });
+
+    it('should return remaining votes needed', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const agent3 = createAgentId(3);
+      const ballots = [createBallot(agent1, true)];
+      const participants = [agent1, agent2, agent3];
+
+      const needed = calculator.calculateVotesNeeded(ballots, participants);
+
+      expect(needed).toBe(2); // Need 2 more yes votes for unanimity
+    });
+
+    it('should return -1 when consensus impossible (no vote with unanimity)', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const ballots = [
+        createBallot(agent1, true),
+        createBallot(agent2, false),
+      ];
+      const participants = [agent1, agent2];
+
+      const needed = calculator.calculateVotesNeeded(ballots, participants, DEFAULT_VOTING_RULES);
+
+      expect(needed).toBe(-1); // Impossible due to no vote
+    });
+  });
+
+  describe('hasVoted', () => {
+    it('should return true if agent has voted', () => {
+      const agent1 = createAgentId(1);
+      const ballots = [createBallot(agent1, true)];
+
+      expect(calculator.hasVoted(agent1, ballots)).toBe(true);
+    });
+
+    it('should return false if agent has not voted', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const ballots = [createBallot(agent1, true)];
+
+      expect(calculator.hasVoted(agent2, ballots)).toBe(false);
+    });
+  });
+
+  describe('analyzePattern', () => {
+    it('should return zero values for empty ballots', () => {
+      const pattern = calculator.analyzePattern([]);
+
+      expect(pattern.averageVoteTime).toBe(0);
+      expect(pattern.quickestVote).toBe(0);
+      expect(pattern.slowestVote).toBe(0);
+      expect(pattern.voteDistribution.yes).toBe(0);
+      expect(pattern.voteDistribution.no).toBe(0);
+    });
+
+    it('should calculate vote distribution', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const agent3 = createAgentId(3);
+      const ballots = [
+        createBallot(agent1, true, '2025-01-01T10:00:00Z'),
+        createBallot(agent2, true, '2025-01-01T10:01:00Z'),
+        createBallot(agent3, false, '2025-01-01T10:02:00Z'),
+      ];
+
+      const pattern = calculator.analyzePattern(ballots);
+
+      expect(pattern.voteDistribution.yes).toBe(2);
+      expect(pattern.voteDistribution.no).toBe(1);
+    });
+
+    it('should calculate timing between sequential votes', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const agent3 = createAgentId(3);
+      // Votes at 10:00:00, 10:00:10, 10:00:20
+      const ballots = [
+        createBallot(agent1, true, '2025-01-01T10:00:00.000Z'),
+        createBallot(agent2, true, '2025-01-01T10:00:10.000Z'),
+        createBallot(agent3, true, '2025-01-01T10:00:20.000Z'),
+      ];
+
+      const pattern = calculator.analyzePattern(ballots);
+
+      // Time between votes: 10 seconds, 10 seconds
+      expect(pattern.averageVoteTime).toBe(10000);
+      expect(pattern.quickestVote).toBe(10000);
+      expect(pattern.slowestVote).toBe(10000);
+    });
+
+    it('should handle varying vote times', () => {
+      const agent1 = createAgentId(1);
+      const agent2 = createAgentId(2);
+      const agent3 = createAgentId(3);
+      // Votes at 10:00:00, 10:00:05, 10:00:15
+      const ballots = [
+        createBallot(agent1, true, '2025-01-01T10:00:00.000Z'),
+        createBallot(agent2, true, '2025-01-01T10:00:05.000Z'),
+        createBallot(agent3, true, '2025-01-01T10:00:15.000Z'),
+      ];
+
+      const pattern = calculator.analyzePattern(ballots);
+
+      // Time between votes: 5 seconds, 10 seconds
+      expect(pattern.averageVoteTime).toBe(7500); // (5000 + 10000) / 2
+      expect(pattern.quickestVote).toBe(5000);
+      expect(pattern.slowestVote).toBe(10000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 1 of Sprint 2 (Issue #26): Foundation layer for the multi-simulation architecture, establishing generic interfaces that all simulation types will use.

### Changes

**Architecture Documentation**
- Added ADR-001: Simulation Type Registration Strategy
- Updated CLAUDE.md with boundary rules and violation examples

**New Core Interfaces (`src/core/simulation/`)**
- `SimulationType.ts` - Branded type with factory and validation
- `ISimulation.ts` - Generic simulation interface with type parameters
- `IAction.ts` - Base action interface for all simulation actions
- `ISimulationConfig.ts` - Configuration and registration interfaces
- `SimulationTypeRegistry.ts` - Static registry for type registration

**Generic Voting (`src/core/voting/`)**
- `BaseBallot.ts` - Minimal ballot interface, BinaryBallot extension
- `VotingRules.ts` - Configurable rules (unanimity vs majority, participation)
- `VoteStatus.ts` - Status, summary, and pattern analysis types
- `IVotingMechanism.ts` - Strategy interface for voting
- `VoteCalculator.ts` - Pure functions for vote calculation

**Generic Relationships (`src/core/relationships/`)**
- `IRelationship.ts` - Generic relationship with type parameter
- `IRelationshipValidator.ts` - Strategy pattern for validation
- `RelationshipGraph.ts` - Graph operations (cycles, depth, queries)

**Tests (71 new tests)**
- `SimulationTypeRegistry.test.ts` - 19 tests
- `GenericVoteCalculator.test.ts` - 20 tests  
- `RelationshipGraph.test.ts` - 32 tests

### Architecture Decisions

Per ADR-001, using **Static Registry with Composition**:
- Generic interfaces in `core/` with no simulation-specific knowledge
- Simulations compose generic utilities, don't inherit
- Registry enables type lookup without coupling
- Boundary rules prevent cross-simulation imports

## Test Plan

- [x] All 71 new tests pass
- [x] All 856 existing tests still pass
- [x] TypeScript compiles without errors
- [ ] Verify interfaces work with future simulation refactoring

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)