### PR TITLE
refactor(di): migrate from legacy TOKENS to typed Tokens pattern

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,8 +138,8 @@ Process commands and queries:
 @injectable()
 export class CreateArgumentHandler implements ICommandHandler<CreateArgumentCommand, CreateArgumentResult> {
   constructor(
-    @inject(TOKENS.ArgumentRepository) private argumentRepo: IArgumentRepository,
-    @inject(TOKENS.ArgumentValidator) private validator: IArgumentValidator
+    @inject(Tokens.ArgumentRepository.symbol) private argumentRepo: IArgumentRepository,
+    @inject(Tokens.ArgumentValidator.symbol) private validator: IArgumentValidator
   ) {}
 
   async handle(command: CreateArgumentCommand): Promise<Result<CreateArgumentResult, Error>> {
@@ -197,7 +197,7 @@ export class ObjectStorage {
 @injectable()
 export class FileArgumentRepository implements IArgumentRepository {
   constructor(
-    @inject(TOKENS.ObjectStorage) private storage: ObjectStorage
+    @inject(Tokens.ObjectStorage.symbol) private storage: ObjectStorage
   ) {}
 
   async save(argument: Argument): Promise<Result<ArgumentId, StorageError>> {
@@ -256,22 +256,22 @@ export class ArgumentCommand {
 // src/interfaces/cli/container-config.ts
 export function configureContainer(): typeof container {
   // Core services
-  container.register(TOKENS.ArgumentValidator, { useClass: ArgumentValidator });
+  container.register(Tokens.ArgumentValidator.symbol, { useClass: ArgumentValidator });
 
   // Infrastructure
-  container.register(TOKENS.ObjectStorage, {
+  container.register(Tokens.ObjectStorage.symbol, {
     useFactory: () => new ObjectStorage('.townhall')
   });
-  container.register(TOKENS.ArgumentRepository, { useClass: FileArgumentRepository });
+  container.register(Tokens.ArgumentRepository.symbol, { useClass: FileArgumentRepository });
 
   // Application handlers
-  container.register(TOKENS.CreateArgumentHandler, { useClass: CreateArgumentHandler });
+  container.register(Tokens.CreateArgumentHandler.symbol, { useClass: CreateArgumentHandler });
 
   // Command bus with handler registration
-  container.register(TOKENS.CommandBus, {
+  container.register(Tokens.CommandBus.symbol, {
     useFactory: () => {
       const bus = new CommandBus();
-      bus.register('CreateArgumentCommand', container.resolve(TOKENS.CreateArgumentHandler));
+      bus.register('CreateArgumentCommand', resolve(Tokens.CreateArgumentHandler));
       return bus;
     }
   });

--- a/src/application/handlers/CheckoutSimulationHandler.ts
+++ b/src/application/handlers/CheckoutSimulationHandler.ts
@@ -10,7 +10,7 @@ import { NotFoundError, StorageError } from '../../shared/errors';
 import { ICommandHandler } from './CommandBus';
 import { CheckoutSimulationCommand } from '../commands/CheckoutSimulationCommand';
 import type { IDebateRepository } from '../../simulations/debate/repositories';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 
 export interface CheckoutSimulationResult {
   readonly simulationId: string;
@@ -22,7 +22,7 @@ export interface CheckoutSimulationResult {
 @injectable()
 export class CheckoutSimulationHandler implements ICommandHandler<CheckoutSimulationCommand, CheckoutSimulationResult> {
   constructor(
-    @inject(DEBATE_TOKENS.SimulationRepository) private readonly simulationRepo: IDebateRepository
+    @inject(DebateTokens.SimulationRepository.symbol) private readonly simulationRepo: IDebateRepository
   ) {}
 
   public async handle(command: CheckoutSimulationCommand): Promise<Result<CheckoutSimulationResult, NotFoundError | StorageError>> {

--- a/src/application/handlers/CreateArgumentHandler.ts
+++ b/src/application/handlers/CreateArgumentHandler.ts
@@ -15,8 +15,8 @@ import { ICitationRepository } from '../../core/repositories/ICitationRepository
 import { ArgumentValidator, Argument, ArgumentId } from '../../simulations/debate';
 import { TimestampGenerator } from '../../core/value-objects/Timestamp';
 import { ICryptoService } from '../../core/services/ICryptoService';
-import { TOKENS } from '../../shared/tokens';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { Tokens } from '../../shared/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 import { isDeductiveStructure, isInductiveStructure, isEmpiricalStructure } from '../utils/structure-guards';
 
 export interface CreateArgumentResult {
@@ -29,12 +29,12 @@ export interface CreateArgumentResult {
 @injectable()
 export class CreateArgumentHandler implements ICommandHandler<CreateArgumentCommand, CreateArgumentResult> {
   constructor(
-    @inject(DEBATE_TOKENS.SimulationRepository) private readonly simulationRepo: IDebateRepository,
-    @inject(DEBATE_TOKENS.ArgumentRepository) private readonly argumentRepo: IArgumentRepository,
-    @inject(TOKENS.AgentRepository) private readonly agentRepo: IAgentRepository,
-    @inject(TOKENS.CitationRepository) private readonly citationRepo: ICitationRepository,
-    @inject(DEBATE_TOKENS.ArgumentValidator) private readonly validator: ArgumentValidator,
-    @inject(TOKENS.CryptoService) private readonly cryptoService: ICryptoService
+    @inject(DebateTokens.SimulationRepository.symbol) private readonly simulationRepo: IDebateRepository,
+    @inject(DebateTokens.ArgumentRepository.symbol) private readonly argumentRepo: IArgumentRepository,
+    @inject(Tokens.AgentRepository.symbol) private readonly agentRepo: IAgentRepository,
+    @inject(Tokens.CitationRepository.symbol) private readonly citationRepo: ICitationRepository,
+    @inject(DebateTokens.ArgumentValidator.symbol) private readonly validator: ArgumentValidator,
+    @inject(Tokens.CryptoService.symbol) private readonly cryptoService: ICryptoService
   ) {}
 
   public async handle(command: CreateArgumentCommand): Promise<Result<CreateArgumentResult, Error>> {

--- a/src/application/handlers/CreateCitationHandler.ts
+++ b/src/application/handlers/CreateCitationHandler.ts
@@ -17,8 +17,8 @@ import { ICitationRepository } from '../../core/repositories/ICitationRepository
 import { ICryptoService } from '../../core/services/ICryptoService';
 import { ICommandHandler } from './CommandBus';
 import { ValidationError } from '../../shared/errors';
-import { TOKENS } from '../../shared/tokens';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { Tokens } from '../../shared/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 import type { IDebateRepository } from '../../simulations/debate/repositories';
 
 @injectable()
@@ -26,9 +26,9 @@ export class CreateCitationHandler
   implements ICommandHandler<CreateCitationCommand, CitationId>
 {
   constructor(
-    @inject(TOKENS.CitationRepository) private readonly citationRepo: ICitationRepository,
-    @inject(TOKENS.CryptoService) private readonly cryptoService: ICryptoService,
-    @inject(DEBATE_TOKENS.SimulationRepository) private readonly simulationRepo: IDebateRepository
+    @inject(Tokens.CitationRepository.symbol) private readonly citationRepo: ICitationRepository,
+    @inject(Tokens.CryptoService.symbol) private readonly cryptoService: ICryptoService,
+    @inject(DebateTokens.SimulationRepository.symbol) private readonly simulationRepo: IDebateRepository
   ) {}
 
   public async handle(command: CreateCitationCommand): Promise<Result<CitationId, Error>> {

--- a/src/application/handlers/GetArgumentChainHandler.ts
+++ b/src/application/handlers/GetArgumentChainHandler.ts
@@ -11,7 +11,7 @@ import { IQueryHandler } from './QueryBus';
 import { GetArgumentChainQuery } from '../queries/GetArgumentChainQuery';
 import type { IArgumentRepository } from '../../simulations/debate/repositories';
 import { Argument } from '../../simulations/debate';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 
 export interface ArgumentNode {
   readonly argument: Argument;
@@ -32,7 +32,7 @@ export interface GetArgumentChainResult {
 @injectable()
 export class GetArgumentChainHandler implements IQueryHandler<GetArgumentChainQuery, GetArgumentChainResult> {
   constructor(
-    @inject(DEBATE_TOKENS.ArgumentRepository) private readonly argumentRepo: IArgumentRepository
+    @inject(DebateTokens.ArgumentRepository.symbol) private readonly argumentRepo: IArgumentRepository
   ) {}
 
   public async handle(query: GetArgumentChainQuery): Promise<Result<GetArgumentChainResult, NotFoundError>> {

--- a/src/application/handlers/GetArgumentHandler.ts
+++ b/src/application/handlers/GetArgumentHandler.ts
@@ -11,7 +11,7 @@ import { IQueryHandler } from './QueryBus';
 import { GetArgumentQuery } from '../queries/GetArgumentQuery';
 import type { IArgumentRepository } from '../../simulations/debate/repositories';
 import { Argument, ArgumentId } from '../../simulations/debate';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 
 export interface GetArgumentResult {
   readonly argument: Argument;
@@ -25,7 +25,7 @@ export interface GetArgumentResult {
 @injectable()
 export class GetArgumentHandler implements IQueryHandler<GetArgumentQuery, GetArgumentResult> {
   constructor(
-    @inject(DEBATE_TOKENS.ArgumentRepository) private readonly argumentRepo: IArgumentRepository
+    @inject(DebateTokens.ArgumentRepository.symbol) private readonly argumentRepo: IArgumentRepository
   ) {}
 
   public async handle(query: GetArgumentQuery): Promise<Result<GetArgumentResult, NotFoundError>> {

--- a/src/application/handlers/GetCitationHandler.ts
+++ b/src/application/handlers/GetCitationHandler.ts
@@ -13,12 +13,12 @@ import { CitationId } from '../../core/value-objects/CitationId';
 import { ICitationRepository } from '../../core/repositories/ICitationRepository';
 import { IQueryHandler } from './QueryBus';
 import { NotFoundError, ValidationError } from '../../shared/errors';
-import { TOKENS } from '../../shared/tokens';
+import { Tokens } from '../../shared/tokens';
 
 @injectable()
 export class GetCitationHandler implements IQueryHandler<GetCitationQuery, Citation> {
   constructor(
-    @inject(TOKENS.CitationRepository) private readonly citationRepo: ICitationRepository
+    @inject(Tokens.CitationRepository.symbol) private readonly citationRepo: ICitationRepository
   ) {}
 
   public async handle(query: GetCitationQuery): Promise<Result<Citation, Error>> {

--- a/src/application/handlers/GetCitationStatsHandler.ts
+++ b/src/application/handlers/GetCitationStatsHandler.ts
@@ -16,12 +16,12 @@ import type { SimulationId } from '../../core/value-objects/SimulationId';
 import { isPeerReviewed } from '../../core/value-objects/CitationType';
 import { IQueryHandler } from './QueryBus';
 import { ValidationError } from '../../shared/errors';
-import { TOKENS } from '../../shared/tokens';
+import { Tokens } from '../../shared/tokens';
 
 @injectable()
 export class GetCitationStatsHandler implements IQueryHandler<GetCitationStatsQuery, CitationStats> {
   constructor(
-    @inject(TOKENS.CitationRepository) private readonly citationRepo: ICitationRepository
+    @inject(Tokens.CitationRepository.symbol) private readonly citationRepo: ICitationRepository
   ) {}
 
   public async handle(query: GetCitationStatsQuery): Promise<Result<CitationStats, Error>> {

--- a/src/application/handlers/GetDebateHistoryHandler.ts
+++ b/src/application/handlers/GetDebateHistoryHandler.ts
@@ -12,8 +12,8 @@ import type { IDebateRepository, IArgumentRepository } from '../../simulations/d
 import { IAgentRepository } from '../../core/repositories/IAgentRepository';
 import { RelationshipBuilder, type ArgumentRelationship } from '../../simulations/debate';
 import { Argument, Rebuttal, Concession } from '../../simulations/debate';
-import { TOKENS } from '../../shared/tokens';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { Tokens } from '../../shared/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 
 export interface ArgumentSummary {
   readonly id: string;
@@ -38,10 +38,10 @@ export interface DebateHistoryResult {
 @injectable()
 export class GetDebateHistoryHandler implements IQueryHandler<GetDebateHistoryQuery, DebateHistoryResult> {
   constructor(
-    @inject(DEBATE_TOKENS.SimulationRepository) private readonly simulationRepo: IDebateRepository,
-    @inject(DEBATE_TOKENS.ArgumentRepository) private readonly argumentRepo: IArgumentRepository,
-    @inject(TOKENS.AgentRepository) private readonly agentRepo: IAgentRepository,
-    @inject(DEBATE_TOKENS.RelationshipBuilder) _relationshipBuilder: RelationshipBuilder
+    @inject(DebateTokens.SimulationRepository.symbol) private readonly simulationRepo: IDebateRepository,
+    @inject(DebateTokens.ArgumentRepository.symbol) private readonly argumentRepo: IArgumentRepository,
+    @inject(Tokens.AgentRepository.symbol) private readonly agentRepo: IAgentRepository,
+    @inject(DebateTokens.RelationshipBuilder.symbol) _relationshipBuilder: RelationshipBuilder
   ) {}
 
   public async handle(query: GetDebateHistoryQuery): Promise<Result<DebateHistoryResult, Error>> {

--- a/src/application/handlers/InitializeDebateHandler.ts
+++ b/src/application/handlers/InitializeDebateHandler.ts
@@ -14,8 +14,8 @@ import { ICryptoService } from '../../core/services/ICryptoService';
 import { DebateSimulation } from '../../simulations/debate';
 import { TimestampGenerator } from '../../core/value-objects/Timestamp';
 import { SimulationId } from '../../core/value-objects/SimulationId';
-import { TOKENS } from '../../shared/tokens';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { Tokens } from '../../shared/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 
 export interface InitializeDebateResult {
   readonly simulationId: SimulationId;
@@ -27,8 +27,8 @@ export interface InitializeDebateResult {
 @injectable()
 export class InitializeDebateHandler implements ICommandHandler<InitializeDebateCommand, InitializeDebateResult> {
   constructor(
-    @inject(DEBATE_TOKENS.SimulationRepository) private readonly simulationRepo: IDebateRepository,
-    @inject(TOKENS.CryptoService) private readonly cryptoService: ICryptoService
+    @inject(DebateTokens.SimulationRepository.symbol) private readonly simulationRepo: IDebateRepository,
+    @inject(Tokens.CryptoService.symbol) private readonly cryptoService: ICryptoService
   ) {}
 
   public async handle(command: InitializeDebateCommand): Promise<Result<InitializeDebateResult, Error>> {

--- a/src/application/handlers/InitializeRepositoryHandler.ts
+++ b/src/application/handlers/InitializeRepositoryHandler.ts
@@ -13,12 +13,12 @@ import { StorageError } from '../../shared/errors';
 import { ICommandHandler } from './CommandBus';
 import { InitializeRepositoryCommand } from '../commands/InitializeRepositoryCommand';
 import { IStorageInitializer } from '../ports/IStorageInitializer';
-import { TOKENS } from '../../shared/tokens';
+import { Tokens } from '../../shared/tokens';
 
 @injectable()
 export class InitializeRepositoryHandler implements ICommandHandler<InitializeRepositoryCommand, void> {
   constructor(
-    @inject(TOKENS.StorageInitializer) private readonly storage: IStorageInitializer
+    @inject(Tokens.StorageInitializer.symbol) private readonly storage: IStorageInitializer
   ) {}
 
   public async handle(_command: InitializeRepositoryCommand): Promise<Result<void, StorageError>> {

--- a/src/application/handlers/SubmitConcessionHandler.ts
+++ b/src/application/handlers/SubmitConcessionHandler.ts
@@ -14,8 +14,8 @@ import type { IArgumentRepository, IDebateRepository } from '../../simulations/d
 import { IAgentRepository } from '../../core/repositories/IAgentRepository';
 import { TimestampGenerator } from '../../core/value-objects/Timestamp';
 import { ICryptoService } from '../../core/services/ICryptoService';
-import { TOKENS } from '../../shared/tokens';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { Tokens } from '../../shared/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 
 export interface SubmitConcessionResult {
   readonly concessionId: ArgumentId;
@@ -27,10 +27,10 @@ export interface SubmitConcessionResult {
 @injectable()
 export class SubmitConcessionHandler implements ICommandHandler<SubmitConcessionCommand, SubmitConcessionResult> {
   constructor(
-    @inject(DEBATE_TOKENS.ArgumentRepository) private readonly argumentRepo: IArgumentRepository,
-    @inject(DEBATE_TOKENS.SimulationRepository) private readonly simulationRepo: IDebateRepository,
-    @inject(TOKENS.AgentRepository) private readonly agentRepo: IAgentRepository,
-    @inject(TOKENS.CryptoService) private readonly cryptoService: ICryptoService
+    @inject(DebateTokens.ArgumentRepository.symbol) private readonly argumentRepo: IArgumentRepository,
+    @inject(DebateTokens.SimulationRepository.symbol) private readonly simulationRepo: IDebateRepository,
+    @inject(Tokens.AgentRepository.symbol) private readonly agentRepo: IAgentRepository,
+    @inject(Tokens.CryptoService.symbol) private readonly cryptoService: ICryptoService
   ) {}
 
   public async handle(command: SubmitConcessionCommand): Promise<Result<SubmitConcessionResult, Error>> {

--- a/src/application/handlers/SubmitRebuttalHandler.ts
+++ b/src/application/handlers/SubmitRebuttalHandler.ts
@@ -14,8 +14,8 @@ import { IAgentRepository } from '../../core/repositories/IAgentRepository';
 import { ArgumentValidator, Rebuttal, ArgumentId, RelationshipBuilder } from '../../simulations/debate';
 import { TimestampGenerator } from '../../core/value-objects/Timestamp';
 import { ICryptoService } from '../../core/services/ICryptoService';
-import { TOKENS } from '../../shared/tokens';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { Tokens } from '../../shared/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 import { isDeductiveStructure, isInductiveStructure, isEmpiricalStructure } from '../utils/structure-guards';
 
 export interface SubmitRebuttalResult {
@@ -29,12 +29,12 @@ export interface SubmitRebuttalResult {
 @injectable()
 export class SubmitRebuttalHandler implements ICommandHandler<SubmitRebuttalCommand, SubmitRebuttalResult> {
   constructor(
-    @inject(DEBATE_TOKENS.ArgumentRepository) private readonly argumentRepo: IArgumentRepository,
-    @inject(DEBATE_TOKENS.SimulationRepository) private readonly simulationRepo: IDebateRepository,
-    @inject(TOKENS.AgentRepository) private readonly agentRepo: IAgentRepository,
-    @inject(DEBATE_TOKENS.ArgumentValidator) private readonly validator: ArgumentValidator,
-    @inject(TOKENS.CryptoService) private readonly cryptoService: ICryptoService,
-    @inject(DEBATE_TOKENS.RelationshipBuilder) private readonly relationshipBuilder: RelationshipBuilder
+    @inject(DebateTokens.ArgumentRepository.symbol) private readonly argumentRepo: IArgumentRepository,
+    @inject(DebateTokens.SimulationRepository.symbol) private readonly simulationRepo: IDebateRepository,
+    @inject(Tokens.AgentRepository.symbol) private readonly agentRepo: IAgentRepository,
+    @inject(DebateTokens.ArgumentValidator.symbol) private readonly validator: ArgumentValidator,
+    @inject(Tokens.CryptoService.symbol) private readonly cryptoService: ICryptoService,
+    @inject(DebateTokens.RelationshipBuilder.symbol) private readonly relationshipBuilder: RelationshipBuilder
   ) {}
 
   public async handle(command: SubmitRebuttalCommand): Promise<Result<SubmitRebuttalResult, Error>> {

--- a/src/application/handlers/VoteToCloseHandler.ts
+++ b/src/application/handlers/VoteToCloseHandler.ts
@@ -15,8 +15,8 @@ import { VoteCalculator } from '../../simulations/debate';
 import { DebateStatus } from '../../simulations/debate';
 import { ITimestampService } from '../../core/services/ITimestampService';
 import { Vote } from '../../core/value-objects/Vote';
-import { TOKENS } from '../../shared/tokens';
-import { DEBATE_TOKENS } from '../../simulations/debate/tokens';
+import { Tokens } from '../../shared/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 
 export interface VoteToCloseResult {
   readonly voteAccepted: boolean;
@@ -29,10 +29,10 @@ export interface VoteToCloseResult {
 @injectable()
 export class VoteToCloseHandler implements ICommandHandler<VoteToCloseCommand, VoteToCloseResult> {
   constructor(
-    @inject(DEBATE_TOKENS.SimulationRepository) private readonly simulationRepo: IDebateRepository,
-    @inject(TOKENS.AgentRepository) private readonly agentRepo: IAgentRepository,
-    @inject(DEBATE_TOKENS.VoteCalculator) private readonly voteCalculator: VoteCalculator,
-    @inject(TOKENS.TimestampService) private readonly timestampService: ITimestampService
+    @inject(DebateTokens.SimulationRepository.symbol) private readonly simulationRepo: IDebateRepository,
+    @inject(Tokens.AgentRepository.symbol) private readonly agentRepo: IAgentRepository,
+    @inject(DebateTokens.VoteCalculator.symbol) private readonly voteCalculator: VoteCalculator,
+    @inject(Tokens.TimestampService.symbol) private readonly timestampService: ITimestampService
   ) {}
 
   public async handle(command: VoteToCloseCommand): Promise<Result<VoteToCloseResult, Error>> {

--- a/src/infrastructure/storage/FileAgentRepository.ts
+++ b/src/infrastructure/storage/FileAgentRepository.ts
@@ -14,7 +14,7 @@ import { ILogger } from '../../application/ports/ILogger';
 import { Agent } from '../../core/entities/Agent';
 import { AgentId } from '../../core/value-objects/AgentId';
 import { AgentFileParser } from './AgentFileParser';
-import { TOKENS } from '../../shared/container';
+import { Tokens } from '../../shared/tokens';
 import { hasErrorCode, isNodeSystemError } from './NodeSystemError';
 
 @injectable()
@@ -27,7 +27,7 @@ export class FileAgentRepository implements IAgentRepository {
   private fileTimestamps: Map<string, number>; // Track mtime for cache invalidation
 
   constructor(
-    @inject(TOKENS.Logger) logger: ILogger,
+    @inject(Tokens.Logger.symbol) logger: ILogger,
     basePath: string = '.townhall'
   ) {
     this.basePath = resolve(basePath);

--- a/src/infrastructure/storage/FileArgumentRepository.ts
+++ b/src/infrastructure/storage/FileArgumentRepository.ts
@@ -24,14 +24,14 @@ import { AgentId } from '../../core/value-objects/AgentId';
 import { TimestampGenerator } from '../../core/value-objects/Timestamp';
 import { ICryptoService } from '../../core/services/ICryptoService';
 import { ObjectStorage } from './ObjectStorage';
-import { TOKENS } from '../../shared/container';
+import { Tokens } from '../../shared/tokens';
 import { ArgumentDataSchema, type ArgumentData, parseStorageData } from './schemas';
 
 @injectable()
 export class FileArgumentRepository implements IArgumentRepository {
   constructor(
-    @inject(TOKENS.ObjectStorage) private readonly storage: ObjectStorage,
-    @inject(TOKENS.CryptoService) private readonly cryptoService: ICryptoService
+    @inject(Tokens.ObjectStorage.symbol) private readonly storage: ObjectStorage,
+    @inject(Tokens.CryptoService.symbol) private readonly cryptoService: ICryptoService
   ) {}
 
   public async save(argument: Argument): Promise<Result<ArgumentId, StorageError>> {

--- a/src/infrastructure/storage/FileCitationRepository.ts
+++ b/src/infrastructure/storage/FileCitationRepository.ts
@@ -14,14 +14,14 @@ import { CitationType } from '../../core/value-objects/CitationType';
 import { TimestampGenerator } from '../../core/value-objects/Timestamp';
 import { ObjectStorage } from './ObjectStorage';
 import { HashResolver } from './HashResolver';
-import { TOKENS } from '../../shared/container';
+import { Tokens } from '../../shared/tokens';
 import { CitationDataSchema, type CitationData, parseStorageData } from './schemas';
 
 @injectable()
 export class FileCitationRepository implements ICitationRepository {
   constructor(
-    @inject(TOKENS.ObjectStorage) private readonly storage: ObjectStorage,
-    @inject(TOKENS.HashResolver) private readonly hashResolver: HashResolver
+    @inject(Tokens.ObjectStorage.symbol) private readonly storage: ObjectStorage,
+    @inject(Tokens.HashResolver.symbol) private readonly hashResolver: HashResolver
   ) {}
 
   public async save(citation: Citation, simulationId: SimulationId): Promise<Result<CitationId, CitationStorageError>> {

--- a/src/infrastructure/storage/FileSimulationRepository.ts
+++ b/src/infrastructure/storage/FileSimulationRepository.ts
@@ -21,7 +21,7 @@ import { SimulationId, SimulationIdGenerator } from '../../core/value-objects/Si
 import { TimestampGenerator } from '../../core/value-objects/Timestamp';
 import { AgentId, AgentIdGenerator } from '../../core/value-objects/AgentId';
 import { ObjectStorage } from './ObjectStorage';
-import { TOKENS } from '../../shared/container';
+import { Tokens } from '../../shared/tokens';
 import { hasErrorCode } from './NodeSystemError';
 import { SimulationDataSchema, type SimulationData, parseStorageData } from './schemas';
 
@@ -30,7 +30,7 @@ export class FileSimulationRepository implements IDebateRepository {
   private readonly basePath: string;
 
   constructor(
-    @inject(TOKENS.ObjectStorage) private readonly storage: ObjectStorage,
+    @inject(Tokens.ObjectStorage.symbol) private readonly storage: ObjectStorage,
     basePath: string = '.townhall'
   ) {
     this.basePath = basePath;

--- a/src/infrastructure/storage/HashResolver.ts
+++ b/src/infrastructure/storage/HashResolver.ts
@@ -8,7 +8,7 @@ import { injectable, inject } from 'tsyringe';
 import { Result, ok, err } from '../../shared/result';
 import { NotFoundError, ConflictError } from '../../shared/errors';
 import { ObjectStorage } from './ObjectStorage';
-import { TOKENS } from '../../shared/container';
+import { Tokens } from '../../shared/tokens';
 
 export interface IHashResolver {
   resolveShortHash(shortHash: string, type: string): Promise<Result<string, Error>>;
@@ -17,7 +17,7 @@ export interface IHashResolver {
 @injectable()
 export class HashResolver implements IHashResolver {
   constructor(
-    @inject(TOKENS.ObjectStorage) private readonly storage: ObjectStorage
+    @inject(Tokens.ObjectStorage.symbol) private readonly storage: ObjectStorage
   ) {}
 
   /**

--- a/src/interfaces/cli/TownhallCLI.ts
+++ b/src/interfaces/cli/TownhallCLI.ts
@@ -13,7 +13,7 @@ import { IQueryBus } from '../../application/handlers/QueryBus';
 import { ILogger } from '../../application/ports/ILogger';
 import type { IArgumentRepository, IDebateRepository } from '../../simulations/debate/repositories';
 import type { ObjectStorage as _ObjectStorage } from '../../infrastructure/storage/ObjectStorage';
-import { TOKENS } from './container-config';
+import { Tokens } from './container-config';
 import { CommandContext } from './base/BaseCommand';
 
 // All commands with Result types
@@ -37,12 +37,12 @@ export class TownhallCLI {
   private readonly context: CommandContext;
 
   constructor(
-    @inject(TOKENS.CommandBus) private readonly commandBus: ICommandBus,
-    @inject(TOKENS.QueryBus) private readonly queryBus: IQueryBus,
-    @inject(TOKENS.Logger) private readonly logger: ILogger,
-    @inject(TOKENS.ObjectStorage) _storage: _ObjectStorage,
-    @inject(TOKENS.ArgumentRepository) private readonly argumentRepository: IArgumentRepository,
-    @inject(TOKENS.SimulationRepository) private readonly simulationRepository: IDebateRepository
+    @inject(Tokens.CommandBus.symbol) private readonly commandBus: ICommandBus,
+    @inject(Tokens.QueryBus.symbol) private readonly queryBus: IQueryBus,
+    @inject(Tokens.Logger.symbol) private readonly logger: ILogger,
+    @inject(Tokens.ObjectStorage.symbol) _storage: _ObjectStorage,
+    @inject(Tokens.ArgumentRepository.symbol) private readonly argumentRepository: IArgumentRepository,
+    @inject(Tokens.SimulationRepository.symbol) private readonly simulationRepository: IDebateRepository
   ) {
     this.program = new Command();
     this.context = {

--- a/src/interfaces/cli/container-config.ts
+++ b/src/interfaces/cli/container-config.ts
@@ -9,8 +9,8 @@
  */
 
 import { container } from 'tsyringe';
-import { TOKENS as FRAMEWORK_TOKENS, Tokens as FrameworkTokens } from '../../shared/tokens';
-import { DEBATE_TOKENS, DebateTokens } from '../../simulations/debate/tokens';
+import { Tokens as FrameworkTokens } from '../../shared/tokens';
+import { DebateTokens } from '../../simulations/debate/tokens';
 import { resolve } from '../../shared/injection';
 
 // Debate services
@@ -20,11 +20,6 @@ import { ArgumentValidator, RelationshipBuilder, VoteCalculator } from '../../si
  * Merged tokens for CLI use - combines framework and debate tokens.
  * This is the single place where cross-boundary token merging happens.
  */
-export const TOKENS = {
-  ...FRAMEWORK_TOKENS,
-  ...DEBATE_TOKENS,
-} as const;
-
 export const Tokens = {
   ...FrameworkTokens,
   ...DebateTokens,
@@ -61,50 +56,50 @@ import { SystemTimestampService } from '../../infrastructure/time/SystemTimestam
 
 export function configureContainer(): typeof container {
   // Core services (no dependencies)
-  container.register(TOKENS.ArgumentValidator, { useClass: ArgumentValidator });
-  container.register(TOKENS.RelationshipBuilder, { useClass: RelationshipBuilder });
-  container.register(TOKENS.VoteCalculator, { useClass: VoteCalculator });
+  container.register(Tokens.ArgumentValidator.symbol, { useClass: ArgumentValidator });
+  container.register(Tokens.RelationshipBuilder.symbol, { useClass: RelationshipBuilder });
+  container.register(Tokens.VoteCalculator.symbol, { useClass: VoteCalculator });
 
   // Infrastructure - Application ports
-  container.register(TOKENS.CryptoService, { useClass: NodeCryptoService });
-  container.register(TOKENS.TimestampService, { useClass: SystemTimestampService });
+  container.register(Tokens.CryptoService.symbol, { useClass: NodeCryptoService });
+  container.register(Tokens.TimestampService.symbol, { useClass: SystemTimestampService });
 
   // Infrastructure - Storage and repositories
   const objectStorage = new ObjectStorage('.townhall');
-  container.register(TOKENS.ObjectStorage, {
+  container.register(Tokens.ObjectStorage.symbol, {
     useValue: objectStorage
   });
   // Register ObjectStorage as IStorageInitializer for application layer
-  container.register(TOKENS.StorageInitializer, {
+  container.register(Tokens.StorageInitializer.symbol, {
     useValue: objectStorage
   });
-  container.register(TOKENS.HashResolver, { useClass: HashResolver });
-  container.register(TOKENS.ArgumentRepository, { useClass: FileArgumentRepository });
-  container.register(TOKENS.SimulationRepository, { useClass: FileSimulationRepository });
-  container.register(TOKENS.AgentRepository, { useClass: FileAgentRepository });
-  container.register(TOKENS.CitationRepository, { useClass: FileCitationRepository });
-  container.register(TOKENS.EventBus, { useClass: InMemoryEventBus });
-  container.register(TOKENS.Logger, {
+  container.register(Tokens.HashResolver.symbol, { useClass: HashResolver });
+  container.register(Tokens.ArgumentRepository.symbol, { useClass: FileArgumentRepository });
+  container.register(Tokens.SimulationRepository.symbol, { useClass: FileSimulationRepository });
+  container.register(Tokens.AgentRepository.symbol, { useClass: FileAgentRepository });
+  container.register(Tokens.CitationRepository.symbol, { useClass: FileCitationRepository });
+  container.register(Tokens.EventBus.symbol, { useClass: InMemoryEventBus });
+  container.register(Tokens.Logger.symbol, {
     useFactory: () => new StructuredLogger({ component: 'townhall-cli' })
   });
 
   // Application layer - handlers
-  container.register(TOKENS.InitializeRepositoryHandler, { useClass: InitializeRepositoryHandler });
-  container.register(TOKENS.InitializeDebateHandler, { useClass: InitializeDebateHandler });
-  container.register(TOKENS.CreateArgumentHandler, { useClass: CreateArgumentHandler });
-  container.register(TOKENS.GetDebateHistoryHandler, { useClass: GetDebateHistoryHandler });
-  container.register(TOKENS.SubmitRebuttalHandler, { useClass: SubmitRebuttalHandler });
-  container.register(TOKENS.SubmitConcessionHandler, { useClass: SubmitConcessionHandler });
-  container.register(TOKENS.VoteToCloseHandler, { useClass: VoteToCloseHandler });
-  container.register(TOKENS.CheckoutSimulationHandler, { useClass: CheckoutSimulationHandler });
-  container.register(TOKENS.GetArgumentHandler, { useClass: GetArgumentHandler });
-  container.register(TOKENS.GetArgumentChainHandler, { useClass: GetArgumentChainHandler });
-  container.register(TOKENS.CreateCitationHandler, { useClass: CreateCitationHandler });
-  container.register(TOKENS.GetCitationHandler, { useClass: GetCitationHandler });
-  container.register(TOKENS.GetCitationStatsHandler, { useClass: GetCitationStatsHandler });
+  container.register(Tokens.InitializeRepositoryHandler.symbol, { useClass: InitializeRepositoryHandler });
+  container.register(Tokens.InitializeDebateHandler.symbol, { useClass: InitializeDebateHandler });
+  container.register(Tokens.CreateArgumentHandler.symbol, { useClass: CreateArgumentHandler });
+  container.register(Tokens.GetDebateHistoryHandler.symbol, { useClass: GetDebateHistoryHandler });
+  container.register(Tokens.SubmitRebuttalHandler.symbol, { useClass: SubmitRebuttalHandler });
+  container.register(Tokens.SubmitConcessionHandler.symbol, { useClass: SubmitConcessionHandler });
+  container.register(Tokens.VoteToCloseHandler.symbol, { useClass: VoteToCloseHandler });
+  container.register(Tokens.CheckoutSimulationHandler.symbol, { useClass: CheckoutSimulationHandler });
+  container.register(Tokens.GetArgumentHandler.symbol, { useClass: GetArgumentHandler });
+  container.register(Tokens.GetArgumentChainHandler.symbol, { useClass: GetArgumentChainHandler });
+  container.register(Tokens.CreateCitationHandler.symbol, { useClass: CreateCitationHandler });
+  container.register(Tokens.GetCitationHandler.symbol, { useClass: GetCitationHandler });
+  container.register(Tokens.GetCitationStatsHandler.symbol, { useClass: GetCitationStatsHandler });
 
   // Application layer - buses with handler registration
-  container.register(TOKENS.CommandBus, {
+  container.register(Tokens.CommandBus.symbol, {
     useFactory: () => {
       const commandBus = new CommandBus();
       // Register command handlers (using typed resolve for type safety)
@@ -120,7 +115,7 @@ export function configureContainer(): typeof container {
     }
   });
 
-  container.register(TOKENS.QueryBus, {
+  container.register(Tokens.QueryBus.symbol, {
     useFactory: () => {
       const queryBus = new QueryBus();
       // Register query handlers (using typed resolve for type safety)

--- a/src/shared/container.ts
+++ b/src/shared/container.ts
@@ -1,9 +1,10 @@
 /**
- * ARCHITECTURE: Dependency Injection container configuration
+ * ARCHITECTURE: Dependency Injection container re-exports
  * Pattern: Re-exports from tokens.ts for centralized access
  * Rationale: Single source of truth for DI tokens
  *
  * For injection tokens, prefer importing from './tokens' directly.
+ * For container configuration, see interfaces/cli/container-config.ts.
  */
 
 import 'reflect-metadata';
@@ -14,9 +15,3 @@ export { Tokens } from './tokens';
 
 // Container instance for global access
 export { container };
-
-// Helper function to configure the container
-export const configureContainer = (): void => {
-  // Configuration will be done during infrastructure setup
-  // This is just the foundation
-};

--- a/src/shared/container.ts
+++ b/src/shared/container.ts
@@ -1,18 +1,16 @@
 /**
  * ARCHITECTURE: Dependency Injection container configuration
- * Pattern: Re-exports from tokens.ts for backward compatibility
- * Rationale: Single source of truth for DI tokens with typed alternatives
+ * Pattern: Re-exports from tokens.ts for centralized access
+ * Rationale: Single source of truth for DI tokens
  *
- * DEPRECATED: Prefer importing from './tokens' for new code.
- * Use Tokens (typed) for new code, TOKENS (symbols) for legacy compatibility.
+ * For injection tokens, prefer importing from './tokens' directly.
  */
 
 import 'reflect-metadata';
 import { container } from 'tsyringe';
 
-// Re-export TOKENS from tokens.ts (single source of truth)
-export { TOKENS, Tokens } from './tokens';
-export type { TokenType } from './tokens';
+// Re-export Tokens from tokens.ts (single source of truth)
+export { Tokens } from './tokens';
 
 // Container instance for global access
 export { container };

--- a/src/shared/tokens.ts
+++ b/src/shared/tokens.ts
@@ -101,48 +101,5 @@ const FrameworkTokens = {
 /**
  * Framework-level typed injection tokens.
  * Simulation-specific tokens should be imported directly from their modules.
- *
- * Use these instead of the legacy Symbol-based TOKENS.
  */
 export const Tokens = FrameworkTokens;
-
-/**
- * Legacy TOKENS constant for backward compatibility during migration.
- * Maps to the symbols from the typed tokens.
- *
- * NOTE: Debate tokens are NOT included here. Import them directly from
- * simulations/debate/tokens or use the merged exports from container-config.
- *
- * @deprecated Use Tokens directly with resolve() instead
- */
-export const TOKENS = {
-  // Framework tokens
-  AgentRepository: FrameworkTokens.AgentRepository.symbol,
-  CitationRepository: FrameworkTokens.CitationRepository.symbol,
-  CryptoService: FrameworkTokens.CryptoService.symbol,
-  TimestampService: FrameworkTokens.TimestampService.symbol,
-  ObjectStorage: FrameworkTokens.ObjectStorage.symbol,
-  EventBus: FrameworkTokens.EventBus.symbol,
-  Logger: FrameworkTokens.Logger.symbol,
-  HashResolver: FrameworkTokens.HashResolver.symbol,
-  StorageInitializer: FrameworkTokens.StorageInitializer.symbol,
-  CommandBus: FrameworkTokens.CommandBus.symbol,
-  QueryBus: FrameworkTokens.QueryBus.symbol,
-  InitializeRepositoryHandler: FrameworkTokens.InitializeRepositoryHandler.symbol,
-  InitializeDebateHandler: FrameworkTokens.InitializeDebateHandler.symbol,
-  CreateArgumentHandler: FrameworkTokens.CreateArgumentHandler.symbol,
-  SubmitRebuttalHandler: FrameworkTokens.SubmitRebuttalHandler.symbol,
-  SubmitConcessionHandler: FrameworkTokens.SubmitConcessionHandler.symbol,
-  VoteToCloseHandler: FrameworkTokens.VoteToCloseHandler.symbol,
-  CheckoutSimulationHandler: FrameworkTokens.CheckoutSimulationHandler.symbol,
-  CreateCitationHandler: FrameworkTokens.CreateCitationHandler.symbol,
-  GetDebateHistoryHandler: FrameworkTokens.GetDebateHistoryHandler.symbol,
-  GetArgumentHandler: FrameworkTokens.GetArgumentHandler.symbol,
-  GetArgumentChainHandler: FrameworkTokens.GetArgumentChainHandler.symbol,
-  GetCitationHandler: FrameworkTokens.GetCitationHandler.symbol,
-  GetCitationStatsHandler: FrameworkTokens.GetCitationStatsHandler.symbol,
-  // Legacy token not yet typed
-  IndexManager: Symbol.for('IndexManager'),
-} as const;
-
-export type TokenType = typeof TOKENS[keyof typeof TOKENS];

--- a/src/simulations/debate/index.ts
+++ b/src/simulations/debate/index.ts
@@ -92,4 +92,4 @@ export { DebateTypeInfo, DebateSimulationTypeConfig } from './DebateConfig';
 export { registerDebateSimulationType } from './register';
 
 // Dependency Injection Tokens
-export { DebateTokens, DEBATE_TOKENS } from './tokens';
+export { DebateTokens } from './tokens';

--- a/src/simulations/debate/tokens.ts
+++ b/src/simulations/debate/tokens.ts
@@ -28,17 +28,3 @@ export const DebateTokens = {
   RelationshipBuilder: createToken<RelationshipBuilder>('RelationshipBuilder'),
   VoteCalculator: createToken<VoteCalculator>('VoteCalculator'),
 } as const;
-
-/**
- * Legacy TOKENS constant for backward compatibility.
- * Maps to the symbols from the typed tokens.
- *
- * @deprecated Use DebateTokens directly with resolve() instead
- */
-export const DEBATE_TOKENS = {
-  ArgumentRepository: DebateTokens.ArgumentRepository.symbol,
-  SimulationRepository: DebateTokens.SimulationRepository.symbol,
-  ArgumentValidator: DebateTokens.ArgumentValidator.symbol,
-  RelationshipBuilder: DebateTokens.RelationshipBuilder.symbol,
-  VoteCalculator: DebateTokens.VoteCalculator.symbol,
-} as const;

--- a/tests/contract/command-contracts.test.ts
+++ b/tests/contract/command-contracts.test.ts
@@ -4,7 +4,7 @@
  */
 
 import 'reflect-metadata';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { container } from 'tsyringe';
 import { configureContainer } from '../../src/interfaces/cli/container-config';
 import { Tokens } from '../../src/interfaces/cli/container-config';
@@ -14,6 +14,11 @@ import { IQueryBus } from '../../src/application/handlers/QueryBus';
 import { InitializeDebateCommand } from '../../src/application/commands/InitializeDebateCommand';
 import { CreateArgumentCommand } from '../../src/application/commands/CreateArgumentCommand';
 import { GetDebateHistoryQuery } from '../../src/application/queries/GetDebateHistoryQuery';
+import type { AgentId } from '../../src/core/value-objects/AgentId';
+import { ArgumentType } from '../../src/simulations/debate';
+import type { InitializeDebateResult } from '../../src/application/handlers/InitializeDebateHandler';
+import type { CreateArgumentResult } from '../../src/application/handlers/CreateArgumentHandler';
+import type { DebateHistoryResult } from '../../src/application/handlers/GetDebateHistoryHandler';
 
 describe('Command/Query Handler Contracts', () => {
   let commandBus: ICommandBus;
@@ -60,10 +65,11 @@ describe('Command/Query Handler Contracts', () => {
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value).toHaveProperty('simulationId');
-        expect(result.value).toHaveProperty('topic');
-        expect(result.value).toHaveProperty('createdAt');
-        expect(result.value.topic).toBe('Test debate topic');
+        const value = result.value as InitializeDebateResult;
+        expect(value).toHaveProperty('simulationId');
+        expect(value).toHaveProperty('topic');
+        expect(value).toHaveProperty('createdAt');
+        expect(value.topic).toBe('Test debate topic');
       }
     });
 
@@ -85,7 +91,8 @@ describe('Command/Query Handler Contracts', () => {
 
       expect(secondResult.isOk()).toBe(true);
       if (secondResult.isOk()) {
-        expect(secondResult.value.topic).toBe('Second debate');
+        const value = secondResult.value as InitializeDebateResult;
+        expect(value.topic).toBe('Second debate');
       }
     });
   });
@@ -120,7 +127,7 @@ A test agent for contract testing.`;
     });
 
     it('should return argument details on success', async () => {
-      const agentId = 'f05482e4-324d-4b50-8be3-a49f870cd968';
+      const agentId = 'f05482e4-324d-4b50-8be3-a49f870cd968' as AgentId;
 
       // Initialize debate first
       await commandBus.execute(
@@ -130,7 +137,7 @@ A test agent for contract testing.`;
 
       const command: CreateArgumentCommand = {
         agentId,
-        type: 'deductive',
+        type: ArgumentType.DEDUCTIVE,
         content: {
           text: 'Test argument',
           structure: {
@@ -158,8 +165,8 @@ A test agent for contract testing.`;
 
     it('should require active debate', async () => {
       const command: CreateArgumentCommand = {
-        agentId: 'f05482e4-324d-4b50-8be3-a49f870cd968',
-        type: 'deductive',
+        agentId: 'f05482e4-324d-4b50-8be3-a49f870cd968' as AgentId,
+        type: ArgumentType.DEDUCTIVE,
         content: {
           text: 'Test argument',
           structure: {
@@ -199,13 +206,14 @@ A test agent for contract testing.`;
 
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value).toHaveProperty('simulationId');
-        expect(result.value).toHaveProperty('topic');
-        expect(result.value).toHaveProperty('status');
-        expect(result.value).toHaveProperty('arguments');
-        expect(result.value).toHaveProperty('participantCount');
-        expect(result.value).toHaveProperty('argumentCount');
-        expect(Array.isArray(result.value.arguments)).toBe(true);
+        const value = result.value as DebateHistoryResult;
+        expect(value).toHaveProperty('simulationId');
+        expect(value).toHaveProperty('topic');
+        expect(value).toHaveProperty('status');
+        expect(value).toHaveProperty('arguments');
+        expect(value).toHaveProperty('participantCount');
+        expect(value).toHaveProperty('argumentCount');
+        expect(Array.isArray(value.arguments)).toBe(true);
       }
     });
 
@@ -222,7 +230,8 @@ A test agent for contract testing.`;
       // Should succeed even with no active debate
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
-        expect(result.value.arguments).toEqual([]);
+        const value = result.value as DebateHistoryResult;
+        expect(value.arguments).toEqual([]);
       }
     });
   });

--- a/tests/contract/command-contracts.test.ts
+++ b/tests/contract/command-contracts.test.ts
@@ -7,7 +7,8 @@ import 'reflect-metadata';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { container } from 'tsyringe';
 import { configureContainer } from '../../src/interfaces/cli/container-config';
-import { TOKENS } from '../../src/shared/container';
+import { Tokens } from '../../src/interfaces/cli/container-config';
+import { resolve } from '../../src/shared/injection';
 import { ICommandBus } from '../../src/application/handlers/CommandBus';
 import { IQueryBus } from '../../src/application/handlers/QueryBus';
 import { InitializeDebateCommand } from '../../src/application/commands/InitializeDebateCommand';
@@ -29,8 +30,8 @@ describe('Command/Query Handler Contracts', () => {
 
     container.clearInstances();
     configureContainer();
-    commandBus = container.resolve(TOKENS.CommandBus);
-    queryBus = container.resolve(TOKENS.QueryBus);
+    commandBus = resolve(Tokens.CommandBus);
+    queryBus = resolve(Tokens.QueryBus);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary

- Complete migration from Symbol-based `TOKENS`/`DEBATE_TOKENS` constants to the new `InjectionToken`-based `Tokens`/`DebateTokens` pattern
- Migrated 21 source files and 1 test file across infrastructure, application, and CLI layers
- Removed deprecated `TOKENS`, `DEBATE_TOKENS`, and `TokenType` exports after confirming no remaining usages
- All 976 tests pass - migration is backward compatible (same underlying symbols)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test -- --run tests/contract/command-contracts.test.ts` - contract tests verify DI resolution works
- [x] Full test suite (`npm test -- --run`) - 976 tests pass

Generated with [Claude Code](https://claude.com/claude-code)