### PR TITLE
Sprint 3 Phase 1: Decision Simulation Structure

### DIFF
--- a/src/simulations/decision/entities/index.ts
+++ b/src/simulations/decision/entities/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Decision simulation entities barrel export
+ * Future: Proposal, Evaluation, Objection entities
+ */
+
+// Placeholder - entities will be added in future phases
+export {};

--- a/src/simulations/decision/index.ts
+++ b/src/simulations/decision/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Decision Simulation Module
+ *
+ * Self-contained simulation type for group decision-making.
+ * Provides value objects, entities, services, and configuration for decision workflows.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   DecisionStatus,
+ *   ProposalId,
+ *   ProposalIdGenerator,
+ *   EvaluationId,
+ *   ObjectionId,
+ *   DecisionTokens,
+ * } from './simulations/decision';
+ * ```
+ */
+
+// Value Objects
+export {
+  DecisionStatus,
+  DECISION_STATUSES,
+  isValidDecisionStatus,
+  parseDecisionStatus,
+  canTransitionTo,
+  getStatusDescription,
+  isTerminalStatus,
+  ProposalId,
+  ProposalIdGenerator,
+  EvaluationId,
+  EvaluationIdGenerator,
+  ObjectionId,
+  ObjectionIdGenerator,
+} from './value-objects';
+
+// Dependency Injection Tokens
+export { DecisionTokens } from './tokens';
+
+// Entities (future phases)
+// export { Proposal, Evaluation, Objection } from './entities';
+
+// Services (future phases)
+// export { ProposalValidator, ConsensusCalculator } from './services';
+
+// Repositories (future phases)
+// export type { IProposalRepository, IDecisionRepository } from './repositories';

--- a/src/simulations/decision/repositories/index.ts
+++ b/src/simulations/decision/repositories/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Decision simulation repository interfaces barrel export
+ * Future: IProposalRepository, IDecisionRepository
+ */
+
+// Placeholder - repository interfaces will be added in future phases
+export {};

--- a/src/simulations/decision/services/index.ts
+++ b/src/simulations/decision/services/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Decision simulation services barrel export
+ * Future: ProposalValidator, ConsensusCalculator, etc.
+ */
+
+// Placeholder - services will be added in future phases
+export {};

--- a/src/simulations/decision/tokens.ts
+++ b/src/simulations/decision/tokens.ts
@@ -1,0 +1,60 @@
+/**
+ * ARCHITECTURE: Decision-specific dependency injection tokens
+ * Pattern: Simulation-specific tokens separated from shared framework tokens
+ * Rationale: Maintains clean layer boundaries - shared/ should not import from simulations/
+ */
+
+import { createToken } from '../../shared/injection';
+
+// Note: Repository and service interfaces will be added in future phases
+// For now, we define the token structure with placeholder types
+
+/**
+ * Placeholder interface for future IProposalRepository
+ * TODO: Replace with actual import when repositories/IProposalRepository.ts is created
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface IProposalRepository {
+  // TEMPORARY: Placeholder - will be replaced with actual interface in future phase
+}
+
+/**
+ * Placeholder interface for future IDecisionRepository
+ * TODO: Replace with actual import when repositories/IDecisionRepository.ts is created
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface IDecisionRepository {
+  // TEMPORARY: Placeholder - will be replaced with actual interface in future phase
+}
+
+/**
+ * Placeholder interface for future ProposalValidator
+ * TODO: Replace with actual import when services/ProposalValidator.ts is created
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface ProposalValidator {
+  // TEMPORARY: Placeholder - will be replaced with actual interface in future phase
+}
+
+/**
+ * Placeholder interface for future ConsensusCalculator
+ * TODO: Replace with actual import when services/ConsensusCalculator.ts is created
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface ConsensusCalculator {
+  // TEMPORARY: Placeholder - will be replaced with actual interface in future phase
+}
+
+/**
+ * Typed injection tokens for decision simulation.
+ * These are separate from shared/tokens.ts to maintain layer boundaries.
+ */
+export const DecisionTokens = {
+  // Repositories
+  ProposalRepository: createToken<IProposalRepository>('DecisionProposalRepository'),
+  SimulationRepository: createToken<IDecisionRepository>('DecisionSimulationRepository'),
+
+  // Services
+  ProposalValidator: createToken<ProposalValidator>('DecisionProposalValidator'),
+  ConsensusCalculator: createToken<ConsensusCalculator>('DecisionConsensusCalculator'),
+} as const;

--- a/src/simulations/decision/value-objects/DecisionStatus.ts
+++ b/src/simulations/decision/value-objects/DecisionStatus.ts
@@ -1,0 +1,80 @@
+/**
+ * ARCHITECTURE: Decision-specific value object
+ * Pattern: String enum for type-safe status tracking
+ * Rationale: Defines the lifecycle states of a decision simulation
+ */
+
+import { Result, ok, err } from '../../../shared/result';
+import { ValidationError } from '../../../shared/errors';
+
+/**
+ * Decision simulation lifecycle states
+ *
+ * - GATHERING_PROPOSALS: Initial phase where agents submit proposals
+ * - EVALUATING: Proposals are being evaluated and discussed
+ * - VOTING: Agents are voting on proposals
+ * - DECIDED: A decision has been reached
+ * - ABANDONED: Decision process was abandoned without resolution
+ */
+export enum DecisionStatus {
+  GATHERING_PROPOSALS = 'gathering_proposals',
+  EVALUATING = 'evaluating',
+  VOTING = 'voting',
+  DECIDED = 'decided',
+  ABANDONED = 'abandoned',
+}
+
+export const DECISION_STATUSES: readonly DecisionStatus[] = Object.values(DecisionStatus);
+
+export function isValidDecisionStatus(value: string): value is DecisionStatus {
+  return DECISION_STATUSES.includes(value as DecisionStatus);
+}
+
+export function parseDecisionStatus(value: string): Result<DecisionStatus, ValidationError> {
+  if (!isValidDecisionStatus(value)) {
+    return err(
+      new ValidationError(
+        `Invalid decision status: ${value}. Must be one of: ${DECISION_STATUSES.join(', ')}`,
+        'decisionStatus'
+      )
+    );
+  }
+  return ok(value);
+}
+
+/**
+ * Valid status transitions for decision simulation
+ */
+export function canTransitionTo(from: DecisionStatus, to: DecisionStatus): boolean {
+  const validTransitions: Record<DecisionStatus, DecisionStatus[]> = {
+    [DecisionStatus.GATHERING_PROPOSALS]: [DecisionStatus.EVALUATING, DecisionStatus.ABANDONED],
+    [DecisionStatus.EVALUATING]: [DecisionStatus.VOTING, DecisionStatus.GATHERING_PROPOSALS, DecisionStatus.ABANDONED],
+    [DecisionStatus.VOTING]: [DecisionStatus.DECIDED, DecisionStatus.EVALUATING, DecisionStatus.ABANDONED],
+    [DecisionStatus.DECIDED]: [], // Terminal state - no transitions
+    [DecisionStatus.ABANDONED]: [], // Terminal state - no transitions
+  };
+
+  return validTransitions[from]?.includes(to) ?? false;
+}
+
+export function getStatusDescription(status: DecisionStatus): string {
+  switch (status) {
+    case DecisionStatus.GATHERING_PROPOSALS:
+      return 'Agents are submitting proposals for consideration';
+    case DecisionStatus.EVALUATING:
+      return 'Proposals are being evaluated and discussed';
+    case DecisionStatus.VOTING:
+      return 'Agents are voting on proposals';
+    case DecisionStatus.DECIDED:
+      return 'A decision has been reached';
+    case DecisionStatus.ABANDONED:
+      return 'Decision process was abandoned without resolution';
+  }
+}
+
+/**
+ * Check if a status is a terminal state (no further transitions possible)
+ */
+export function isTerminalStatus(status: DecisionStatus): boolean {
+  return status === DecisionStatus.DECIDED || status === DecisionStatus.ABANDONED;
+}

--- a/src/simulations/decision/value-objects/EvaluationId.ts
+++ b/src/simulations/decision/value-objects/EvaluationId.ts
@@ -1,0 +1,60 @@
+/**
+ * ARCHITECTURE: Decision-specific value object - content-addressed identifier
+ * Pattern: SHA-256 hashing with injected crypto service
+ * Rationale: Pure domain logic without Node.js dependencies
+ */
+
+import { Brand } from '../../../shared/types';
+import { Result, ok, err } from '../../../shared/result';
+import { ValidationError } from '../../../shared/errors';
+import { ICryptoService } from '../../../core/services/ICryptoService';
+
+export type EvaluationId = Brand<string, 'EvaluationId'>;
+
+export class EvaluationIdGenerator {
+  /**
+   * Generate EvaluationId from content using injected crypto service
+   * @param content Content to hash for ID generation
+   * @param cryptoService Cryptographic service for SHA-256 hashing
+   */
+  public static fromContent(content: string, cryptoService: ICryptoService): EvaluationId {
+    const hash = cryptoService.hash(content, 'sha256');
+    return hash as EvaluationId;
+  }
+
+  /**
+   * Create EvaluationId from existing hash string
+   * @param hash SHA-256 hash string to validate and convert
+   * @returns Result with EvaluationId or ValidationError
+   */
+  public static fromHash(hash: string): Result<EvaluationId, ValidationError> {
+    if (!this.isValidHash(hash)) {
+      return err(new ValidationError('Invalid SHA-256 hash format for EvaluationId'));
+    }
+    return ok(hash as EvaluationId);
+  }
+
+  /**
+   * Extract short hash prefix from EvaluationId
+   * @param id Full EvaluationId
+   * @param length Number of characters for short hash (default 7)
+   */
+  public static getShortHash(id: EvaluationId, length: number = 7): string {
+    return id.slice(0, length);
+  }
+
+  /**
+   * Expand short hash to full EvaluationId if unambiguous
+   * @param shortHash Short hash prefix to expand
+   * @param availableIds List of available EvaluationIds to match against
+   * @returns Full EvaluationId if exactly one match, null otherwise
+   */
+  public static expandShortHash(shortHash: string, availableIds: EvaluationId[]): EvaluationId | null {
+    const matches = availableIds.filter(id => id.startsWith(shortHash));
+    return matches.length === 1 ? matches[0]! : null;
+  }
+
+  private static isValidHash(value: string): boolean {
+    return /^[a-f0-9]{64}$/i.test(value);
+  }
+}

--- a/src/simulations/decision/value-objects/ObjectionId.ts
+++ b/src/simulations/decision/value-objects/ObjectionId.ts
@@ -1,0 +1,60 @@
+/**
+ * ARCHITECTURE: Decision-specific value object - content-addressed identifier
+ * Pattern: SHA-256 hashing with injected crypto service
+ * Rationale: Pure domain logic without Node.js dependencies
+ */
+
+import { Brand } from '../../../shared/types';
+import { Result, ok, err } from '../../../shared/result';
+import { ValidationError } from '../../../shared/errors';
+import { ICryptoService } from '../../../core/services/ICryptoService';
+
+export type ObjectionId = Brand<string, 'ObjectionId'>;
+
+export class ObjectionIdGenerator {
+  /**
+   * Generate ObjectionId from content using injected crypto service
+   * @param content Content to hash for ID generation
+   * @param cryptoService Cryptographic service for SHA-256 hashing
+   */
+  public static fromContent(content: string, cryptoService: ICryptoService): ObjectionId {
+    const hash = cryptoService.hash(content, 'sha256');
+    return hash as ObjectionId;
+  }
+
+  /**
+   * Create ObjectionId from existing hash string
+   * @param hash SHA-256 hash string to validate and convert
+   * @returns Result with ObjectionId or ValidationError
+   */
+  public static fromHash(hash: string): Result<ObjectionId, ValidationError> {
+    if (!this.isValidHash(hash)) {
+      return err(new ValidationError('Invalid SHA-256 hash format for ObjectionId'));
+    }
+    return ok(hash as ObjectionId);
+  }
+
+  /**
+   * Extract short hash prefix from ObjectionId
+   * @param id Full ObjectionId
+   * @param length Number of characters for short hash (default 7)
+   */
+  public static getShortHash(id: ObjectionId, length: number = 7): string {
+    return id.slice(0, length);
+  }
+
+  /**
+   * Expand short hash to full ObjectionId if unambiguous
+   * @param shortHash Short hash prefix to expand
+   * @param availableIds List of available ObjectionIds to match against
+   * @returns Full ObjectionId if exactly one match, null otherwise
+   */
+  public static expandShortHash(shortHash: string, availableIds: ObjectionId[]): ObjectionId | null {
+    const matches = availableIds.filter(id => id.startsWith(shortHash));
+    return matches.length === 1 ? matches[0]! : null;
+  }
+
+  private static isValidHash(value: string): boolean {
+    return /^[a-f0-9]{64}$/i.test(value);
+  }
+}

--- a/src/simulations/decision/value-objects/ProposalId.ts
+++ b/src/simulations/decision/value-objects/ProposalId.ts
@@ -1,0 +1,60 @@
+/**
+ * ARCHITECTURE: Decision-specific value object - content-addressed identifier
+ * Pattern: SHA-256 hashing with injected crypto service
+ * Rationale: Pure domain logic without Node.js dependencies
+ */
+
+import { Brand } from '../../../shared/types';
+import { Result, ok, err } from '../../../shared/result';
+import { ValidationError } from '../../../shared/errors';
+import { ICryptoService } from '../../../core/services/ICryptoService';
+
+export type ProposalId = Brand<string, 'ProposalId'>;
+
+export class ProposalIdGenerator {
+  /**
+   * Generate ProposalId from content using injected crypto service
+   * @param content Content to hash for ID generation
+   * @param cryptoService Cryptographic service for SHA-256 hashing
+   */
+  public static fromContent(content: string, cryptoService: ICryptoService): ProposalId {
+    const hash = cryptoService.hash(content, 'sha256');
+    return hash as ProposalId;
+  }
+
+  /**
+   * Create ProposalId from existing hash string
+   * @param hash SHA-256 hash string to validate and convert
+   * @returns Result with ProposalId or ValidationError
+   */
+  public static fromHash(hash: string): Result<ProposalId, ValidationError> {
+    if (!this.isValidHash(hash)) {
+      return err(new ValidationError('Invalid SHA-256 hash format for ProposalId'));
+    }
+    return ok(hash as ProposalId);
+  }
+
+  /**
+   * Extract short hash prefix from ProposalId
+   * @param id Full ProposalId
+   * @param length Number of characters for short hash (default 7)
+   */
+  public static getShortHash(id: ProposalId, length: number = 7): string {
+    return id.slice(0, length);
+  }
+
+  /**
+   * Expand short hash to full ProposalId if unambiguous
+   * @param shortHash Short hash prefix to expand
+   * @param availableIds List of available ProposalIds to match against
+   * @returns Full ProposalId if exactly one match, null otherwise
+   */
+  public static expandShortHash(shortHash: string, availableIds: ProposalId[]): ProposalId | null {
+    const matches = availableIds.filter(id => id.startsWith(shortHash));
+    return matches.length === 1 ? matches[0]! : null;
+  }
+
+  private static isValidHash(value: string): boolean {
+    return /^[a-f0-9]{64}$/i.test(value);
+  }
+}

--- a/src/simulations/decision/value-objects/index.ts
+++ b/src/simulations/decision/value-objects/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Decision value objects public exports
+ */
+
+export {
+  DecisionStatus,
+  DECISION_STATUSES,
+  isValidDecisionStatus,
+  parseDecisionStatus,
+  canTransitionTo,
+  getStatusDescription,
+  isTerminalStatus,
+} from './DecisionStatus';
+
+export { ProposalId, ProposalIdGenerator } from './ProposalId';
+export { EvaluationId, EvaluationIdGenerator } from './EvaluationId';
+export { ObjectionId, ObjectionIdGenerator } from './ObjectionId';

--- a/tests/unit/simulations/decision/value-objects/DecisionStatus.test.ts
+++ b/tests/unit/simulations/decision/value-objects/DecisionStatus.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for DecisionStatus module
+ * Tests status enumeration, type guards, transitions, and utility functions
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DecisionStatus,
+  DECISION_STATUSES,
+  isValidDecisionStatus,
+  parseDecisionStatus,
+  canTransitionTo,
+  getStatusDescription,
+  isTerminalStatus,
+} from '../../../../../src/simulations/decision/value-objects/DecisionStatus';
+
+describe('DecisionStatus', () => {
+  describe('DecisionStatus enum', () => {
+    it('should have GATHERING_PROPOSALS status', () => {
+      expect(DecisionStatus.GATHERING_PROPOSALS).toBe('gathering_proposals');
+    });
+
+    it('should have EVALUATING status', () => {
+      expect(DecisionStatus.EVALUATING).toBe('evaluating');
+    });
+
+    it('should have VOTING status', () => {
+      expect(DecisionStatus.VOTING).toBe('voting');
+    });
+
+    it('should have DECIDED status', () => {
+      expect(DecisionStatus.DECIDED).toBe('decided');
+    });
+
+    it('should have ABANDONED status', () => {
+      expect(DecisionStatus.ABANDONED).toBe('abandoned');
+    });
+
+    it('should have exactly 5 statuses', () => {
+      expect(Object.values(DecisionStatus)).toHaveLength(5);
+    });
+  });
+
+  describe('DECISION_STATUSES', () => {
+    it('should be a readonly array of all statuses', () => {
+      expect(DECISION_STATUSES).toContain(DecisionStatus.GATHERING_PROPOSALS);
+      expect(DECISION_STATUSES).toContain(DecisionStatus.EVALUATING);
+      expect(DECISION_STATUSES).toContain(DecisionStatus.VOTING);
+      expect(DECISION_STATUSES).toContain(DecisionStatus.DECIDED);
+      expect(DECISION_STATUSES).toContain(DecisionStatus.ABANDONED);
+      expect(DECISION_STATUSES).toHaveLength(5);
+    });
+  });
+
+  describe('isValidDecisionStatus', () => {
+    it('should return true for all valid statuses', () => {
+      expect(isValidDecisionStatus('gathering_proposals')).toBe(true);
+      expect(isValidDecisionStatus('evaluating')).toBe(true);
+      expect(isValidDecisionStatus('voting')).toBe(true);
+      expect(isValidDecisionStatus('decided')).toBe(true);
+      expect(isValidDecisionStatus('abandoned')).toBe(true);
+    });
+
+    it('should return true for enum values', () => {
+      expect(isValidDecisionStatus(DecisionStatus.GATHERING_PROPOSALS)).toBe(true);
+      expect(isValidDecisionStatus(DecisionStatus.EVALUATING)).toBe(true);
+      expect(isValidDecisionStatus(DecisionStatus.VOTING)).toBe(true);
+      expect(isValidDecisionStatus(DecisionStatus.DECIDED)).toBe(true);
+      expect(isValidDecisionStatus(DecisionStatus.ABANDONED)).toBe(true);
+    });
+
+    it('should return false for invalid status strings', () => {
+      expect(isValidDecisionStatus('invalid')).toBe(false);
+      expect(isValidDecisionStatus('GATHERING_PROPOSALS')).toBe(false);
+      expect(isValidDecisionStatus('Evaluating')).toBe(false);
+      expect(isValidDecisionStatus('')).toBe(false);
+      expect(isValidDecisionStatus('active')).toBe(false);
+    });
+  });
+
+  describe('parseDecisionStatus', () => {
+    it('should return Ok for valid statuses', () => {
+      const result = parseDecisionStatus('gathering_proposals');
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe(DecisionStatus.GATHERING_PROPOSALS);
+      }
+    });
+
+    it('should return Ok for all valid status strings', () => {
+      for (const status of DECISION_STATUSES) {
+        const result = parseDecisionStatus(status);
+        expect(result.isOk()).toBe(true);
+      }
+    });
+
+    it('should return Err for invalid status', () => {
+      const result = parseDecisionStatus('invalid');
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain('Invalid decision status');
+        expect(result.error.message).toContain('invalid');
+        expect(result.error.field).toBe('decisionStatus');
+      }
+    });
+
+    it('should return Err for empty string', () => {
+      const result = parseDecisionStatus('');
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('canTransitionTo', () => {
+    describe('from GATHERING_PROPOSALS', () => {
+      it('should allow transition to EVALUATING', () => {
+        expect(canTransitionTo(DecisionStatus.GATHERING_PROPOSALS, DecisionStatus.EVALUATING)).toBe(true);
+      });
+
+      it('should allow transition to ABANDONED', () => {
+        expect(canTransitionTo(DecisionStatus.GATHERING_PROPOSALS, DecisionStatus.ABANDONED)).toBe(true);
+      });
+
+      it('should not allow transition to VOTING', () => {
+        expect(canTransitionTo(DecisionStatus.GATHERING_PROPOSALS, DecisionStatus.VOTING)).toBe(false);
+      });
+
+      it('should not allow transition to DECIDED', () => {
+        expect(canTransitionTo(DecisionStatus.GATHERING_PROPOSALS, DecisionStatus.DECIDED)).toBe(false);
+      });
+
+      it('should not allow transition to self', () => {
+        expect(canTransitionTo(DecisionStatus.GATHERING_PROPOSALS, DecisionStatus.GATHERING_PROPOSALS)).toBe(false);
+      });
+    });
+
+    describe('from EVALUATING', () => {
+      it('should allow transition to VOTING', () => {
+        expect(canTransitionTo(DecisionStatus.EVALUATING, DecisionStatus.VOTING)).toBe(true);
+      });
+
+      it('should allow transition back to GATHERING_PROPOSALS', () => {
+        expect(canTransitionTo(DecisionStatus.EVALUATING, DecisionStatus.GATHERING_PROPOSALS)).toBe(true);
+      });
+
+      it('should allow transition to ABANDONED', () => {
+        expect(canTransitionTo(DecisionStatus.EVALUATING, DecisionStatus.ABANDONED)).toBe(true);
+      });
+
+      it('should not allow transition to DECIDED', () => {
+        expect(canTransitionTo(DecisionStatus.EVALUATING, DecisionStatus.DECIDED)).toBe(false);
+      });
+    });
+
+    describe('from VOTING', () => {
+      it('should allow transition to DECIDED', () => {
+        expect(canTransitionTo(DecisionStatus.VOTING, DecisionStatus.DECIDED)).toBe(true);
+      });
+
+      it('should allow transition back to EVALUATING', () => {
+        expect(canTransitionTo(DecisionStatus.VOTING, DecisionStatus.EVALUATING)).toBe(true);
+      });
+
+      it('should allow transition to ABANDONED', () => {
+        expect(canTransitionTo(DecisionStatus.VOTING, DecisionStatus.ABANDONED)).toBe(true);
+      });
+
+      it('should not allow transition to GATHERING_PROPOSALS', () => {
+        expect(canTransitionTo(DecisionStatus.VOTING, DecisionStatus.GATHERING_PROPOSALS)).toBe(false);
+      });
+    });
+
+    describe('from DECIDED (terminal state)', () => {
+      it('should not allow any transitions', () => {
+        expect(canTransitionTo(DecisionStatus.DECIDED, DecisionStatus.GATHERING_PROPOSALS)).toBe(false);
+        expect(canTransitionTo(DecisionStatus.DECIDED, DecisionStatus.EVALUATING)).toBe(false);
+        expect(canTransitionTo(DecisionStatus.DECIDED, DecisionStatus.VOTING)).toBe(false);
+        expect(canTransitionTo(DecisionStatus.DECIDED, DecisionStatus.ABANDONED)).toBe(false);
+        expect(canTransitionTo(DecisionStatus.DECIDED, DecisionStatus.DECIDED)).toBe(false);
+      });
+    });
+
+    describe('from ABANDONED (terminal state)', () => {
+      it('should not allow any transitions', () => {
+        expect(canTransitionTo(DecisionStatus.ABANDONED, DecisionStatus.GATHERING_PROPOSALS)).toBe(false);
+        expect(canTransitionTo(DecisionStatus.ABANDONED, DecisionStatus.EVALUATING)).toBe(false);
+        expect(canTransitionTo(DecisionStatus.ABANDONED, DecisionStatus.VOTING)).toBe(false);
+        expect(canTransitionTo(DecisionStatus.ABANDONED, DecisionStatus.DECIDED)).toBe(false);
+        expect(canTransitionTo(DecisionStatus.ABANDONED, DecisionStatus.ABANDONED)).toBe(false);
+      });
+    });
+  });
+
+  describe('getStatusDescription', () => {
+    it('should return description for GATHERING_PROPOSALS', () => {
+      const desc = getStatusDescription(DecisionStatus.GATHERING_PROPOSALS);
+      expect(desc).toBe('Agents are submitting proposals for consideration');
+    });
+
+    it('should return description for EVALUATING', () => {
+      const desc = getStatusDescription(DecisionStatus.EVALUATING);
+      expect(desc).toBe('Proposals are being evaluated and discussed');
+    });
+
+    it('should return description for VOTING', () => {
+      const desc = getStatusDescription(DecisionStatus.VOTING);
+      expect(desc).toBe('Agents are voting on proposals');
+    });
+
+    it('should return description for DECIDED', () => {
+      const desc = getStatusDescription(DecisionStatus.DECIDED);
+      expect(desc).toBe('A decision has been reached');
+    });
+
+    it('should return description for ABANDONED', () => {
+      const desc = getStatusDescription(DecisionStatus.ABANDONED);
+      expect(desc).toBe('Decision process was abandoned without resolution');
+    });
+
+    it('should return non-empty description for all statuses', () => {
+      for (const status of DECISION_STATUSES) {
+        const desc = getStatusDescription(status);
+        expect(desc.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('isTerminalStatus', () => {
+    it('should return true for DECIDED', () => {
+      expect(isTerminalStatus(DecisionStatus.DECIDED)).toBe(true);
+    });
+
+    it('should return true for ABANDONED', () => {
+      expect(isTerminalStatus(DecisionStatus.ABANDONED)).toBe(true);
+    });
+
+    it('should return false for GATHERING_PROPOSALS', () => {
+      expect(isTerminalStatus(DecisionStatus.GATHERING_PROPOSALS)).toBe(false);
+    });
+
+    it('should return false for EVALUATING', () => {
+      expect(isTerminalStatus(DecisionStatus.EVALUATING)).toBe(false);
+    });
+
+    it('should return false for VOTING', () => {
+      expect(isTerminalStatus(DecisionStatus.VOTING)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/simulations/decision/value-objects/EvaluationId.test.ts
+++ b/tests/unit/simulations/decision/value-objects/EvaluationId.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for EvaluationId module
+ * Tests ID generation, validation, and utility functions
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EvaluationIdGenerator, EvaluationId } from '../../../../../src/simulations/decision/value-objects/EvaluationId';
+import { ICryptoService } from '../../../../../src/core/services/ICryptoService';
+
+// Mock crypto service for testing
+const createMockCryptoService = (hashValue: string): ICryptoService => ({
+  randomBytes: (_size: number) => new Uint8Array(32),
+  hash: (_data: string, _algorithm: 'sha256' | 'sha512') => hashValue,
+});
+
+describe('EvaluationIdGenerator', () => {
+  const validHash = 'c'.repeat(64);
+  const anotherValidHash = 'd'.repeat(64);
+  const invalidHashTooShort = 'c'.repeat(63);
+  const invalidHashTooLong = 'c'.repeat(65);
+  const invalidHashBadChars = 'x'.repeat(64);
+
+  describe('fromContent', () => {
+    it('should generate EvaluationId from content using crypto service', () => {
+      const mockCrypto = createMockCryptoService(validHash);
+      const id = EvaluationIdGenerator.fromContent('evaluation content', mockCrypto);
+      expect(id).toBe(validHash);
+    });
+
+    it('should use sha256 algorithm', () => {
+      let calledWithAlgorithm: string | undefined;
+      const mockCrypto: ICryptoService = {
+        randomBytes: (_size: number) => new Uint8Array(32),
+        hash: (_data: string, algorithm: 'sha256' | 'sha512') => {
+          calledWithAlgorithm = algorithm;
+          return validHash;
+        },
+      };
+
+      EvaluationIdGenerator.fromContent('test', mockCrypto);
+      expect(calledWithAlgorithm).toBe('sha256');
+    });
+
+    it('should pass content to crypto service', () => {
+      let calledWithData: string | undefined;
+      const mockCrypto: ICryptoService = {
+        randomBytes: (_size: number) => new Uint8Array(32),
+        hash: (data: string, _algorithm: 'sha256' | 'sha512') => {
+          calledWithData = data;
+          return validHash;
+        },
+      };
+
+      EvaluationIdGenerator.fromContent('my evaluation content', mockCrypto);
+      expect(calledWithData).toBe('my evaluation content');
+    });
+  });
+
+  describe('fromHash', () => {
+    it('should return Ok for valid SHA-256 hash', () => {
+      const result = EvaluationIdGenerator.fromHash(validHash);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe(validHash);
+      }
+    });
+
+    it('should return Ok for lowercase hex hash', () => {
+      const result = EvaluationIdGenerator.fromHash(validHash.toLowerCase());
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should return Ok for uppercase hex hash', () => {
+      const result = EvaluationIdGenerator.fromHash(validHash.toUpperCase());
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should return Err for hash that is too short', () => {
+      const result = EvaluationIdGenerator.fromHash(invalidHashTooShort);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain('Invalid SHA-256 hash format for EvaluationId');
+      }
+    });
+
+    it('should return Err for hash that is too long', () => {
+      const result = EvaluationIdGenerator.fromHash(invalidHashTooLong);
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('should return Err for hash with invalid characters', () => {
+      const result = EvaluationIdGenerator.fromHash(invalidHashBadChars);
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('should return Err for empty string', () => {
+      const result = EvaluationIdGenerator.fromHash('');
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('getShortHash', () => {
+    it('should return first 7 characters by default', () => {
+      const id = validHash as EvaluationId;
+      const short = EvaluationIdGenerator.getShortHash(id);
+      expect(short).toBe(validHash.slice(0, 7));
+      expect(short.length).toBe(7);
+    });
+
+    it('should return specified number of characters', () => {
+      const id = validHash as EvaluationId;
+      expect(EvaluationIdGenerator.getShortHash(id, 5)).toBe(validHash.slice(0, 5));
+      expect(EvaluationIdGenerator.getShortHash(id, 12)).toBe(validHash.slice(0, 12));
+    });
+  });
+
+  describe('expandShortHash', () => {
+    it('should return full ID when exactly one match exists', () => {
+      const ids = [validHash, anotherValidHash] as EvaluationId[];
+      const result = EvaluationIdGenerator.expandShortHash('ccc', ids);
+      expect(result).toBe(validHash);
+    });
+
+    it('should return null when no matches exist', () => {
+      const ids = [validHash, anotherValidHash] as EvaluationId[];
+      const result = EvaluationIdGenerator.expandShortHash('fff', ids);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when multiple matches exist', () => {
+      const ids = ['cde'.padEnd(64, '0'), 'cdf'.padEnd(64, '0')] as EvaluationId[];
+      const result = EvaluationIdGenerator.expandShortHash('cd', ids);
+      expect(result).toBeNull();
+    });
+
+    it('should return the ID when full hash is provided', () => {
+      const ids = [validHash] as EvaluationId[];
+      const result = EvaluationIdGenerator.expandShortHash(validHash, ids);
+      expect(result).toBe(validHash);
+    });
+
+    it('should return null for empty availableIds array', () => {
+      const result = EvaluationIdGenerator.expandShortHash('ccc', []);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/unit/simulations/decision/value-objects/ObjectionId.test.ts
+++ b/tests/unit/simulations/decision/value-objects/ObjectionId.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for ObjectionId module
+ * Tests ID generation, validation, and utility functions
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectionIdGenerator, ObjectionId } from '../../../../../src/simulations/decision/value-objects/ObjectionId';
+import { ICryptoService } from '../../../../../src/core/services/ICryptoService';
+
+// Mock crypto service for testing
+const createMockCryptoService = (hashValue: string): ICryptoService => ({
+  randomBytes: (_size: number) => new Uint8Array(32),
+  hash: (_data: string, _algorithm: 'sha256' | 'sha512') => hashValue,
+});
+
+describe('ObjectionIdGenerator', () => {
+  const validHash = 'e'.repeat(64);
+  const anotherValidHash = 'f'.repeat(64);
+  const invalidHashTooShort = 'e'.repeat(63);
+  const invalidHashTooLong = 'e'.repeat(65);
+  const invalidHashBadChars = 'z'.repeat(64);
+
+  describe('fromContent', () => {
+    it('should generate ObjectionId from content using crypto service', () => {
+      const mockCrypto = createMockCryptoService(validHash);
+      const id = ObjectionIdGenerator.fromContent('objection content', mockCrypto);
+      expect(id).toBe(validHash);
+    });
+
+    it('should use sha256 algorithm', () => {
+      let calledWithAlgorithm: string | undefined;
+      const mockCrypto: ICryptoService = {
+        randomBytes: (_size: number) => new Uint8Array(32),
+        hash: (_data: string, algorithm: 'sha256' | 'sha512') => {
+          calledWithAlgorithm = algorithm;
+          return validHash;
+        },
+      };
+
+      ObjectionIdGenerator.fromContent('test', mockCrypto);
+      expect(calledWithAlgorithm).toBe('sha256');
+    });
+
+    it('should pass content to crypto service', () => {
+      let calledWithData: string | undefined;
+      const mockCrypto: ICryptoService = {
+        randomBytes: (_size: number) => new Uint8Array(32),
+        hash: (data: string, _algorithm: 'sha256' | 'sha512') => {
+          calledWithData = data;
+          return validHash;
+        },
+      };
+
+      ObjectionIdGenerator.fromContent('my objection content', mockCrypto);
+      expect(calledWithData).toBe('my objection content');
+    });
+  });
+
+  describe('fromHash', () => {
+    it('should return Ok for valid SHA-256 hash', () => {
+      const result = ObjectionIdGenerator.fromHash(validHash);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe(validHash);
+      }
+    });
+
+    it('should return Ok for lowercase hex hash', () => {
+      const result = ObjectionIdGenerator.fromHash(validHash.toLowerCase());
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should return Ok for uppercase hex hash', () => {
+      const result = ObjectionIdGenerator.fromHash(validHash.toUpperCase());
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should return Err for hash that is too short', () => {
+      const result = ObjectionIdGenerator.fromHash(invalidHashTooShort);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain('Invalid SHA-256 hash format for ObjectionId');
+      }
+    });
+
+    it('should return Err for hash that is too long', () => {
+      const result = ObjectionIdGenerator.fromHash(invalidHashTooLong);
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('should return Err for hash with invalid characters', () => {
+      const result = ObjectionIdGenerator.fromHash(invalidHashBadChars);
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('should return Err for empty string', () => {
+      const result = ObjectionIdGenerator.fromHash('');
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('getShortHash', () => {
+    it('should return first 7 characters by default', () => {
+      const id = validHash as ObjectionId;
+      const short = ObjectionIdGenerator.getShortHash(id);
+      expect(short).toBe(validHash.slice(0, 7));
+      expect(short.length).toBe(7);
+    });
+
+    it('should return specified number of characters', () => {
+      const id = validHash as ObjectionId;
+      expect(ObjectionIdGenerator.getShortHash(id, 4)).toBe(validHash.slice(0, 4));
+      expect(ObjectionIdGenerator.getShortHash(id, 15)).toBe(validHash.slice(0, 15));
+    });
+  });
+
+  describe('expandShortHash', () => {
+    it('should return full ID when exactly one match exists', () => {
+      const ids = [validHash, anotherValidHash] as ObjectionId[];
+      const result = ObjectionIdGenerator.expandShortHash('eee', ids);
+      expect(result).toBe(validHash);
+    });
+
+    it('should return null when no matches exist', () => {
+      const ids = [validHash, anotherValidHash] as ObjectionId[];
+      const result = ObjectionIdGenerator.expandShortHash('aaa', ids);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when multiple matches exist', () => {
+      const ids = ['ef0'.padEnd(64, '0'), 'ef1'.padEnd(64, '0')] as ObjectionId[];
+      const result = ObjectionIdGenerator.expandShortHash('ef', ids);
+      expect(result).toBeNull();
+    });
+
+    it('should return the ID when full hash is provided', () => {
+      const ids = [validHash] as ObjectionId[];
+      const result = ObjectionIdGenerator.expandShortHash(validHash, ids);
+      expect(result).toBe(validHash);
+    });
+
+    it('should return null for empty availableIds array', () => {
+      const result = ObjectionIdGenerator.expandShortHash('eee', []);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/unit/simulations/decision/value-objects/ProposalId.test.ts
+++ b/tests/unit/simulations/decision/value-objects/ProposalId.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for ProposalId module
+ * Tests ID generation, validation, and utility functions
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ProposalIdGenerator, ProposalId } from '../../../../../src/simulations/decision/value-objects/ProposalId';
+import { ICryptoService } from '../../../../../src/core/services/ICryptoService';
+
+// Mock crypto service for testing
+const createMockCryptoService = (hashValue: string): ICryptoService => ({
+  randomBytes: (_size: number) => new Uint8Array(32),
+  hash: (_data: string, _algorithm: 'sha256' | 'sha512') => hashValue,
+});
+
+describe('ProposalIdGenerator', () => {
+  const validHash = 'a'.repeat(64);
+  const anotherValidHash = 'b'.repeat(64);
+  const invalidHashTooShort = 'a'.repeat(63);
+  const invalidHashTooLong = 'a'.repeat(65);
+  const invalidHashBadChars = 'g'.repeat(64);
+
+  describe('fromContent', () => {
+    it('should generate ProposalId from content using crypto service', () => {
+      const mockCrypto = createMockCryptoService(validHash);
+      const id = ProposalIdGenerator.fromContent('test content', mockCrypto);
+      expect(id).toBe(validHash);
+    });
+
+    it('should use sha256 algorithm', () => {
+      let calledWithAlgorithm: string | undefined;
+      const mockCrypto: ICryptoService = {
+        randomBytes: (_size: number) => new Uint8Array(32),
+        hash: (_data: string, algorithm: 'sha256' | 'sha512') => {
+          calledWithAlgorithm = algorithm;
+          return validHash;
+        },
+      };
+
+      ProposalIdGenerator.fromContent('test', mockCrypto);
+      expect(calledWithAlgorithm).toBe('sha256');
+    });
+
+    it('should pass content to crypto service', () => {
+      let calledWithData: string | undefined;
+      const mockCrypto: ICryptoService = {
+        randomBytes: (_size: number) => new Uint8Array(32),
+        hash: (data: string, _algorithm: 'sha256' | 'sha512') => {
+          calledWithData = data;
+          return validHash;
+        },
+      };
+
+      ProposalIdGenerator.fromContent('my proposal content', mockCrypto);
+      expect(calledWithData).toBe('my proposal content');
+    });
+  });
+
+  describe('fromHash', () => {
+    it('should return Ok for valid SHA-256 hash', () => {
+      const result = ProposalIdGenerator.fromHash(validHash);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe(validHash);
+      }
+    });
+
+    it('should return Ok for lowercase hex hash', () => {
+      const result = ProposalIdGenerator.fromHash(validHash.toLowerCase());
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should return Ok for uppercase hex hash', () => {
+      const result = ProposalIdGenerator.fromHash(validHash.toUpperCase());
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should return Ok for mixed case hex hash', () => {
+      const mixedCase = 'aAbBcCdDeEfF'.repeat(5) + 'aaaa';
+      const result = ProposalIdGenerator.fromHash(mixedCase);
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('should return Err for hash that is too short', () => {
+      const result = ProposalIdGenerator.fromHash(invalidHashTooShort);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain('Invalid SHA-256 hash format for ProposalId');
+      }
+    });
+
+    it('should return Err for hash that is too long', () => {
+      const result = ProposalIdGenerator.fromHash(invalidHashTooLong);
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('should return Err for hash with invalid characters', () => {
+      const result = ProposalIdGenerator.fromHash(invalidHashBadChars);
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('should return Err for empty string', () => {
+      const result = ProposalIdGenerator.fromHash('');
+      expect(result.isErr()).toBe(true);
+    });
+
+    it('should return Err for non-hex characters', () => {
+      const result = ProposalIdGenerator.fromHash('z'.repeat(64));
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('getShortHash', () => {
+    it('should return first 7 characters by default', () => {
+      const id = validHash as ProposalId;
+      const short = ProposalIdGenerator.getShortHash(id);
+      expect(short).toBe(validHash.slice(0, 7));
+      expect(short.length).toBe(7);
+    });
+
+    it('should return specified number of characters', () => {
+      const id = validHash as ProposalId;
+      expect(ProposalIdGenerator.getShortHash(id, 3)).toBe(validHash.slice(0, 3));
+      expect(ProposalIdGenerator.getShortHash(id, 10)).toBe(validHash.slice(0, 10));
+      expect(ProposalIdGenerator.getShortHash(id, 64)).toBe(validHash);
+    });
+
+    it('should handle length of 1', () => {
+      const id = validHash as ProposalId;
+      expect(ProposalIdGenerator.getShortHash(id, 1)).toBe(validHash[0]);
+    });
+  });
+
+  describe('expandShortHash', () => {
+    it('should return full ID when exactly one match exists', () => {
+      const ids = [validHash, anotherValidHash] as ProposalId[];
+      const result = ProposalIdGenerator.expandShortHash('aaa', ids);
+      expect(result).toBe(validHash);
+    });
+
+    it('should return null when no matches exist', () => {
+      const ids = [validHash, anotherValidHash] as ProposalId[];
+      const result = ProposalIdGenerator.expandShortHash('ccc', ids);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when multiple matches exist', () => {
+      const ids = ['abc'.padEnd(64, '0'), 'abd'.padEnd(64, '0')] as ProposalId[];
+      const result = ProposalIdGenerator.expandShortHash('ab', ids);
+      expect(result).toBeNull();
+    });
+
+    it('should return the ID when full hash is provided', () => {
+      const ids = [validHash] as ProposalId[];
+      const result = ProposalIdGenerator.expandShortHash(validHash, ids);
+      expect(result).toBe(validHash);
+    });
+
+    it('should return null for empty availableIds array', () => {
+      const result = ProposalIdGenerator.expandShortHash('aaa', []);
+      expect(result).toBeNull();
+    });
+
+    it('should be case-sensitive when matching', () => {
+      const ids = [validHash.toLowerCase()] as ProposalId[];
+      const result = ProposalIdGenerator.expandShortHash(validHash.toUpperCase().slice(0, 3), ids);
+      // Depends on whether the hash is stored in lowercase
+      // Since validHash is 'a'.repeat(64), upper/lower doesn't matter here
+      // Let's test with a more specific case
+      const mixedIds = ['abcdef'.padEnd(64, '0')] as ProposalId[];
+      const upperResult = ProposalIdGenerator.expandShortHash('ABC', mixedIds);
+      expect(upperResult).toBeNull(); // Should not match lowercase
+    });
+  });
+});

--- a/tests/unit/simulations/decision/value-objects/ProposalId.test.ts
+++ b/tests/unit/simulations/decision/value-objects/ProposalId.test.ts
@@ -162,11 +162,7 @@ describe('ProposalIdGenerator', () => {
     });
 
     it('should be case-sensitive when matching', () => {
-      const ids = [validHash.toLowerCase()] as ProposalId[];
-      const result = ProposalIdGenerator.expandShortHash(validHash.toUpperCase().slice(0, 3), ids);
-      // Depends on whether the hash is stored in lowercase
-      // Since validHash is 'a'.repeat(64), upper/lower doesn't matter here
-      // Let's test with a more specific case
+      // Test with mixed case ID to verify case sensitivity
       const mixedIds = ['abcdef'.padEnd(64, '0')] as ProposalId[];
       const upperResult = ProposalIdGenerator.expandShortHash('ABC', mixedIds);
       expect(upperResult).toBeNull(); // Should not match lowercase


### PR DESCRIPTION
## Summary

Implements the foundational directory structure and value objects for the Decision simulation type as specified in Issue #39.

This is Phase 1 of Sprint 3, which validates the multi-simulation architecture by implementing a second simulation type (Decision-Making).

### Changes

**Directory Structure:**
- `src/simulations/decision/` - New simulation module following hexagonal architecture
- `entities/`, `services/`, `repositories/` - Placeholder subdirectories with barrel exports
- `value-objects/` - Core value objects for the decision domain

**Value Objects:**
- `DecisionStatus` - Lifecycle states (gathering_proposals, evaluating, voting, decided, abandoned) with state machine transitions
- `ProposalId` - Content-addressed branded type with SHA-256 hashing
- `EvaluationId` - Content-addressed branded type for evaluation tracking
- `ObjectionId` - Content-addressed branded type for objection tracking

**Infrastructure:**
- `tokens.ts` - DI tokens following `DecisionTokens.*` pattern
- `index.ts` - Main barrel export for public API

**Tests:**
- 95 unit tests covering all value objects
- Tests for status transitions, ID generation, hash validation

### Architecture Compliance

- ✅ NO imports from `simulations/debate/` (boundary rule enforced)
- ✅ NO imports from `simulations/decision/` in `core/` (layer isolation)
- ✅ Patterns match debate simulation structure exactly
- ✅ Uses shared utilities from `core/` and `shared/`

### Acceptance Criteria

- [x] Directory structure matches debate simulation pattern
- [x] All value objects compile without errors
- [x] DI tokens follow `DecisionTokens.*` pattern
- [x] Index exports all public APIs
- [x] All tests pass (95 tests)

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes  
- [x] `npm test -- tests/unit/simulations/decision` - 95 tests pass
- [x] Verify no cross-simulation imports with grep

## Related

- Closes #39
- Part of Sprint 3 (tracked in #25)
- Enables Phase 2: Decision Core Entities (#40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)